### PR TITLE
Changing the pixel flagging scheme

### DIFF
--- a/brahmap/_extensions/repixelization.cpp
+++ b/brahmap/_extensions/repixelization.cpp
@@ -11,12 +11,13 @@ template <typename dint, typename dfloat>
 void repixelize_pol_I(                      //
     const ssize_t new_npix,                 //
     const dint *__restrict observed_pixels, //
+    dint *__restrict hit_counts,            //
     dfloat *__restrict weighted_counts      //
 ) {
 
-  // #pragma omp parallel for simd
   for (ssize_t idx = 0; idx < new_npix; ++idx) {
     dint pixel = observed_pixels[idx];
+    hit_counts[idx] = hit_counts[pixel];
     weighted_counts[idx] = weighted_counts[pixel];
   } // for
 
@@ -28,6 +29,7 @@ template <typename dint, typename dfloat>
 void repixelize_pol_QU(                     //
     const ssize_t new_npix,                 //
     const dint *__restrict observed_pixels, //
+    dint *__restrict hit_counts,            //
     dfloat *__restrict weighted_counts,     //
     dfloat *__restrict weighted_sin_sq,     //
     dfloat *__restrict weighted_cos_sq,     //
@@ -35,9 +37,9 @@ void repixelize_pol_QU(                     //
     dfloat *__restrict one_over_determinant //
 ) {
 
-  // #pragma omp parallel for simd
   for (ssize_t idx = 0; idx < new_npix; ++idx) {
     dint pixel = observed_pixels[idx];
+    hit_counts[idx] = hit_counts[pixel];
     weighted_counts[idx] = weighted_counts[pixel];
     weighted_sin_sq[idx] = weighted_sin_sq[pixel];
     weighted_cos_sq[idx] = weighted_cos_sq[pixel];
@@ -53,6 +55,7 @@ template <typename dint, typename dfloat>
 void repixelize_pol_IQU(                    //
     const ssize_t new_npix,                 //
     const dint *__restrict observed_pixels, //
+    dint *__restrict hit_counts,            //
     dfloat *__restrict weighted_counts,     //
     dfloat *__restrict weighted_sin_sq,     //
     dfloat *__restrict weighted_cos_sq,     //
@@ -62,9 +65,9 @@ void repixelize_pol_IQU(                    //
     dfloat *__restrict one_over_determinant //
 ) {
 
-  // #pragma omp parallel for simd
   for (ssize_t idx = 0; idx < new_npix; ++idx) {
     dint pixel = observed_pixels[idx];
+    hit_counts[idx] = hit_counts[pixel];
     weighted_counts[idx] = weighted_counts[pixel];
     weighted_sin_sq[idx] = weighted_sin_sq[pixel];
     weighted_cos_sq[idx] = weighted_cos_sq[pixel];
@@ -103,24 +106,29 @@ template <template <typename, int = py::array::c_style> class buffer_t,
 std::function<void(                       //
     const ssize_t new_npix,               //
     const buffer_t<dint> observed_pixels, //
+    buffer_t<dint> hit_counts,            //
     buffer_t<dfloat> weighted_counts      //
     )>
     numpy_bind_repixelize_pol_I =        //
     [](const ssize_t new_npix,           //
        const py::buffer observed_pixels, //
+       py::buffer hit_counts,            //
        py::buffer weighted_counts        //
     ) {
       py::buffer_info observed_pixels_info = observed_pixels.request();
+      py::buffer_info hit_counts_info = hit_counts.request();
       py::buffer_info weighted_counts_info = weighted_counts.request();
 
       const dint *observed_pixels_ptr =
           reinterpret_cast<const dint *>(observed_pixels_info.ptr);
+      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
       dfloat *weighted_counts_ptr =
           reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
 
       repixelize_pol_I(        //
           new_npix,            //
           observed_pixels_ptr, //
+          hit_counts_ptr,      //
           weighted_counts_ptr  //
       );
     }; // numpy_bind_repixelize_pol_I()
@@ -130,6 +138,7 @@ template <template <typename, int = py::array::c_style> class buffer_t,
 std::function<void(                       //
     const ssize_t new_npix,               //
     const buffer_t<dint> observed_pixels, //
+    buffer_t<dint> hit_counts,            //
     buffer_t<dfloat> weighted_counts,     //
     buffer_t<dfloat> weighted_sin_sq,     //
     buffer_t<dfloat> weighted_cos_sq,     //
@@ -139,6 +148,7 @@ std::function<void(                       //
     numpy_bind_repixelize_pol_QU =       //
     [](const ssize_t new_npix,           //
        const py::buffer observed_pixels, //
+       py::buffer hit_counts,            //
        py::buffer weighted_counts,       //
        py::buffer weighted_sin_sq,       //
        py::buffer weighted_cos_sq,       //
@@ -146,6 +156,7 @@ std::function<void(                       //
        py::buffer one_over_determinant   //
     ) {
       py::buffer_info observed_pixels_info = observed_pixels.request();
+      py::buffer_info hit_counts_info = hit_counts.request();
       py::buffer_info weighted_counts_info = weighted_counts.request();
       py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
       py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
@@ -155,6 +166,7 @@ std::function<void(                       //
 
       const dint *observed_pixels_ptr =
           reinterpret_cast<const dint *>(observed_pixels_info.ptr);
+      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
       dfloat *weighted_counts_ptr =
           reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
       dfloat *weighted_sin_sq_ptr =
@@ -169,6 +181,7 @@ std::function<void(                       //
       repixelize_pol_QU(           //
           new_npix,                //
           observed_pixels_ptr,     //
+          hit_counts_ptr,          //
           weighted_counts_ptr,     //
           weighted_sin_sq_ptr,     //
           weighted_cos_sq_ptr,     //
@@ -182,6 +195,7 @@ template <template <typename, int = py::array::c_style> class buffer_t,
 std::function<void(                       //
     const ssize_t new_npix,               //
     const buffer_t<dint> observed_pixels, //
+    buffer_t<dint> hit_counts,            //
     buffer_t<dfloat> weighted_counts,     //
     buffer_t<dfloat> weighted_sin_sq,     //
     buffer_t<dfloat> weighted_cos_sq,     //
@@ -193,6 +207,7 @@ std::function<void(                       //
     numpy_bind_repixelize_pol_IQU =      //
     [](const ssize_t new_npix,           //
        const py::buffer observed_pixels, //
+       py::buffer hit_counts,            //
        py::buffer weighted_counts,       //
        py::buffer weighted_sin_sq,       //
        py::buffer weighted_cos_sq,       //
@@ -202,6 +217,7 @@ std::function<void(                       //
        py::buffer one_over_determinant   //
     ) {
       py::buffer_info observed_pixels_info = observed_pixels.request();
+      py::buffer_info hit_counts_info = hit_counts.request();
       py::buffer_info weighted_counts_info = weighted_counts.request();
       py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
       py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
@@ -213,6 +229,7 @@ std::function<void(                       //
 
       const dint *observed_pixels_ptr =
           reinterpret_cast<const dint *>(observed_pixels_info.ptr);
+      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
       dfloat *weighted_counts_ptr =
           reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
       dfloat *weighted_sin_sq_ptr =
@@ -231,6 +248,7 @@ std::function<void(                       //
       repixelize_pol_IQU(          //
           new_npix,                //
           observed_pixels_ptr,     //
+          hit_counts_ptr,          //
           weighted_counts_ptr,     //
           weighted_sin_sq_ptr,     //
           weighted_cos_sq_ptr,     //
@@ -282,24 +300,28 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_I<py::array_t, int32_t, float>,
         py::arg("new_npix"),                    //
         py::arg("observed_pixels").noconvert(), //
+        py::arg("hit_counts").noconvert(),      //
         py::arg("weighted_counts").noconvert()  //
   );
   m.def("repixelize_pol_I",
         numpy_bind_repixelize_pol_I<py::array_t, int64_t, float>,
         py::arg("new_npix"),                    //
         py::arg("observed_pixels").noconvert(), //
+        py::arg("hit_counts").noconvert(),      //
         py::arg("weighted_counts").noconvert()  //
   );
   m.def("repixelize_pol_I",
         numpy_bind_repixelize_pol_I<py::array_t, int32_t, double>,
         py::arg("new_npix"),                    //
         py::arg("observed_pixels").noconvert(), //
+        py::arg("hit_counts").noconvert(),      //
         py::arg("weighted_counts").noconvert()  //
   );
   m.def("repixelize_pol_I",
         numpy_bind_repixelize_pol_I<py::array_t, int64_t, double>,
         py::arg("new_npix"),                    //
         py::arg("observed_pixels").noconvert(), //
+        py::arg("hit_counts").noconvert(),      //
         py::arg("weighted_counts").noconvert()  //
   );
 
@@ -307,6 +329,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_QU<py::array_t, int32_t, float>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -317,6 +340,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_QU<py::array_t, int64_t, float>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -327,6 +351,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_QU<py::array_t, int32_t, double>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -337,6 +362,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_QU<py::array_t, int64_t, double>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -348,6 +374,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_IQU<py::array_t, int32_t, float>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -360,6 +387,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_IQU<py::array_t, int64_t, float>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -372,6 +400,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_IQU<py::array_t, int32_t, double>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //
@@ -384,6 +413,7 @@ PYBIND11_MODULE(repixelize, m) {
         numpy_bind_repixelize_pol_IQU<py::array_t, int64_t, double>,
         py::arg("new_npix"),                        //
         py::arg("observed_pixels").noconvert(),     //
+        py::arg("hit_counts").noconvert(),          //
         py::arg("weighted_counts").noconvert(),     //
         py::arg("weighted_sin_sq").noconvert(),     //
         py::arg("weighted_cos_sq").noconvert(),     //

--- a/brahmap/core/process_time_samples.py
+++ b/brahmap/core/process_time_samples.py
@@ -285,6 +285,7 @@ class ProcessTimeSamples(object):
         return hit_counts
 
     def _compute_weights(self, pol_angles: np.ndarray, noise_weights: np.ndarray):
+        self.hit_counts = np.zeros(self.npix, dtype=self.pointings.dtype)
         self.weighted_counts = np.zeros(self.npix, dtype=self.dtype_float)
         self.observed_pixels = np.zeros(self.npix, dtype=self.pointings.dtype)
         self.__old2new_pixel = np.zeros(self.npix, dtype=self.pointings.dtype)
@@ -297,6 +298,7 @@ class ProcessTimeSamples(object):
                 pointings=self.pointings,
                 pointings_flag=self.pointings_flag,
                 noise_weights=noise_weights,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
                 observed_pixels=self.observed_pixels,
                 __old2new_pixel=self.__old2new_pixel,
@@ -322,6 +324,7 @@ class ProcessTimeSamples(object):
                     pointings_flag=self.pointings_flag,
                     noise_weights=noise_weights,
                     pol_angles=pol_angles,
+                    hit_counts=self.hit_counts,
                     weighted_counts=self.weighted_counts,
                     sin2phi=self.sin2phi,
                     cos2phi=self.cos2phi,
@@ -343,6 +346,7 @@ class ProcessTimeSamples(object):
                     pointings_flag=self.pointings_flag,
                     noise_weights=noise_weights,
                     pol_angles=pol_angles,
+                    hit_counts=self.hit_counts,
                     weighted_counts=self.weighted_counts,
                     sin2phi=self.sin2phi,
                     cos2phi=self.cos2phi,
@@ -359,7 +363,7 @@ class ProcessTimeSamples(object):
                 solver_type=self.solver_type,
                 npix=self.npix,
                 threshold=self.threshold,
-                weighted_counts=self.weighted_counts,
+                hit_counts=self.hit_counts,
                 one_over_determinant=self.one_over_determinant,
                 observed_pixels=self.observed_pixels,
                 __old2new_pixel=self.__old2new_pixel,
@@ -373,15 +377,18 @@ class ProcessTimeSamples(object):
             repixelize.repixelize_pol_I(
                 new_npix=self.new_npix,
                 observed_pixels=self.observed_pixels,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
             )
 
+            self.hit_counts.resize(self.new_npix, refcheck=False)
             self.weighted_counts.resize(self.new_npix, refcheck=False)
 
         elif self.solver_type == SolverType.QU:
             repixelize.repixelize_pol_QU(
                 new_npix=self.new_npix,
                 observed_pixels=self.observed_pixels,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
                 weighted_sin_sq=self.weighted_sin_sq,
                 weighted_cos_sq=self.weighted_cos_sq,
@@ -389,6 +396,7 @@ class ProcessTimeSamples(object):
                 one_over_determinant=self.one_over_determinant,
             )
 
+            self.hit_counts.resize(self.new_npix, refcheck=False)
             self.weighted_counts.resize(self.new_npix, refcheck=False)
             self.weighted_sin_sq.resize(self.new_npix, refcheck=False)
             self.weighted_cos_sq.resize(self.new_npix, refcheck=False)
@@ -399,6 +407,7 @@ class ProcessTimeSamples(object):
             repixelize.repixelize_pol_IQU(
                 new_npix=self.new_npix,
                 observed_pixels=self.observed_pixels,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
                 weighted_sin_sq=self.weighted_sin_sq,
                 weighted_cos_sq=self.weighted_cos_sq,
@@ -408,6 +417,7 @@ class ProcessTimeSamples(object):
                 one_over_determinant=self.one_over_determinant,
             )
 
+            self.hit_counts.resize(self.new_npix, refcheck=False)
             self.weighted_counts.resize(self.new_npix, refcheck=False)
             self.weighted_sin_sq.resize(self.new_npix, refcheck=False)
             self.weighted_cos_sq.resize(self.new_npix, refcheck=False)

--- a/tests/py_ProcessTimeSamples.py
+++ b/tests/py_ProcessTimeSamples.py
@@ -117,6 +117,7 @@ class ProcessTimeSamples(object):
         if self.solver_type == SolverType.I:
             (
                 self.new_npix,
+                self.hit_counts,
                 self.weighted_counts,
                 self.observed_pixels,
                 self.__old2new_pixel,
@@ -134,6 +135,7 @@ class ProcessTimeSamples(object):
         else:
             if self.solver_type == SolverType.QU:
                 (
+                    self.hit_counts,
                     self.weighted_counts,
                     self.sin2phi,
                     self.cos2phi,
@@ -154,6 +156,7 @@ class ProcessTimeSamples(object):
 
             elif self.solver_type == SolverType.IQU:
                 (
+                    self.hit_counts,
                     self.weighted_counts,
                     self.sin2phi,
                     self.cos2phi,
@@ -183,21 +186,23 @@ class ProcessTimeSamples(object):
                 npix=self.npix,
                 solver_type=self.solver_type,
                 threshold=self.threshold,
-                weighted_counts=self.weighted_counts,
+                hit_counts=self.hit_counts,
                 one_over_determinant=self.one_over_determinant,
                 dtype_int=self.pointings.dtype,
             )
 
     def _repixelization(self):
         if self.solver_type == SolverType.I:
-            self.weighted_counts = rp.repixelize_pol_I(
+            self.hit_counts, self.weighted_counts = rp.repixelize_pol_I(
                 new_npix=self.new_npix,
                 observed_pixels=self.observed_pixels,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
             )
 
         elif self.solver_type == SolverType.QU:
             (
+                self.hit_counts,
                 self.weighted_counts,
                 self.weighted_sin_sq,
                 self.weighted_cos_sq,
@@ -206,6 +211,7 @@ class ProcessTimeSamples(object):
             ) = rp.repixelize_pol_QU(
                 new_npix=self.new_npix,
                 observed_pixels=self.observed_pixels,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
                 weighted_sin_sq=self.weighted_sin_sq,
                 weighted_cos_sq=self.weighted_cos_sq,
@@ -215,6 +221,7 @@ class ProcessTimeSamples(object):
 
         elif self.solver_type == SolverType.IQU:
             (
+                self.hit_counts,
                 self.weighted_counts,
                 self.weighted_sin_sq,
                 self.weighted_cos_sq,
@@ -225,6 +232,7 @@ class ProcessTimeSamples(object):
             ) = rp.repixelize_pol_IQU(
                 new_npix=self.new_npix,
                 observed_pixels=self.observed_pixels,
+                hit_counts=self.hit_counts,
                 weighted_counts=self.weighted_counts,
                 weighted_sin_sq=self.weighted_sin_sq,
                 weighted_cos_sq=self.weighted_cos_sq,

--- a/tests/py_Repixelization.py
+++ b/tests/py_Repixelization.py
@@ -2,20 +2,26 @@ import numpy as np
 
 
 def repixelize_pol_I(
-    new_npix: int, observed_pixels: np.ndarray, weighted_counts: np.ndarray
+    new_npix: int,
+    observed_pixels: np.ndarray,
+    hit_counts: np.ndarray,
+    weighted_counts: np.ndarray,
 ):
     for idx in range(new_npix):
         pixel = observed_pixels[idx]
+        hit_counts[idx] = hit_counts[pixel]
         weighted_counts[idx] = weighted_counts[pixel]
 
+    hit_counts.resize(new_npix, refcheck=False)
     weighted_counts.resize(new_npix, refcheck=False)
 
-    return weighted_counts
+    return hit_counts, weighted_counts
 
 
 def repixelize_pol_QU(
     new_npix: int,
     observed_pixels: np.ndarray,
+    hit_counts: np.ndarray,
     weighted_counts: np.ndarray,
     weighted_sin_sq: np.ndarray,
     weighted_cos_sq: np.ndarray,
@@ -24,12 +30,14 @@ def repixelize_pol_QU(
 ):
     for idx in range(new_npix):
         pixel = observed_pixels[idx]
+        hit_counts[idx] = hit_counts[pixel]
         weighted_counts[idx] = weighted_counts[pixel]
         weighted_sin_sq[idx] = weighted_sin_sq[pixel]
         weighted_cos_sq[idx] = weighted_cos_sq[pixel]
         weighted_sincos[idx] = weighted_sincos[pixel]
         one_over_determinant[idx] = 1.0 / one_over_determinant[pixel]
 
+    hit_counts.resize(new_npix, refcheck=False)
     weighted_counts.resize(new_npix, refcheck=False)
     weighted_sin_sq.resize(new_npix, refcheck=False)
     weighted_cos_sq.resize(new_npix, refcheck=False)
@@ -37,6 +45,7 @@ def repixelize_pol_QU(
     one_over_determinant.resize(new_npix, refcheck=False)
 
     return (
+        hit_counts,
         weighted_counts,
         weighted_sin_sq,
         weighted_cos_sq,
@@ -48,6 +57,7 @@ def repixelize_pol_QU(
 def repixelize_pol_IQU(
     new_npix: int,
     observed_pixels: np.ndarray,
+    hit_counts: np.ndarray,
     weighted_counts: np.ndarray,
     weighted_sin_sq: np.ndarray,
     weighted_cos_sq: np.ndarray,
@@ -58,6 +68,7 @@ def repixelize_pol_IQU(
 ):
     for idx in range(new_npix):
         pixel = observed_pixels[idx]
+        hit_counts[idx] = hit_counts[pixel]
         weighted_counts[idx] = weighted_counts[pixel]
         weighted_sin_sq[idx] = weighted_sin_sq[pixel]
         weighted_cos_sq[idx] = weighted_cos_sq[pixel]
@@ -66,6 +77,7 @@ def repixelize_pol_IQU(
         weighted_cos[idx] = weighted_cos[pixel]
         one_over_determinant[idx] = 1.0 / one_over_determinant[pixel]
 
+    hit_counts.resize(new_npix, refcheck=False)
     weighted_counts.resize(new_npix, refcheck=False)
     weighted_sin_sq.resize(new_npix, refcheck=False)
     weighted_cos_sq.resize(new_npix, refcheck=False)
@@ -75,6 +87,7 @@ def repixelize_pol_IQU(
     one_over_determinant.resize(new_npix, refcheck=False)
 
     return (
+        hit_counts,
         weighted_counts,
         weighted_sin_sq,
         weighted_cos_sq,

--- a/tests/test_compute_weights_cpp.py
+++ b/tests/test_compute_weights_cpp.py
@@ -105,6 +105,7 @@ initfloat64 = InitFloat64Params()
 )
 class TestComputeWeights(InitCommonParams):
     def test_compute_weights_pol_I(self, initint, initfloat, rtol, atol):
+        cpp_hit_counts = np.zeros(self.npix, dtype=initint.dtype)
         cpp_weighted_counts = np.zeros(self.npix, dtype=initfloat.dtype)
         cpp_observed_pixels = np.zeros(self.npix, dtype=initint.dtype)
         cpp_old2new_pixel = np.zeros(self.npix, dtype=initint.dtype)
@@ -116,6 +117,7 @@ class TestComputeWeights(InitCommonParams):
             initint.pointings,
             self.pointings_flag,
             initfloat.noise_weights,
+            cpp_hit_counts,
             cpp_weighted_counts,
             cpp_observed_pixels,
             cpp_old2new_pixel,
@@ -125,6 +127,7 @@ class TestComputeWeights(InitCommonParams):
 
         (
             py_new_npix,
+            py_hit_counts,
             py_weighted_counts,
             py_observed_pixels,
             py_old2new_pixel,
@@ -142,6 +145,7 @@ class TestComputeWeights(InitCommonParams):
         cpp_observed_pixels.resize(cpp_new_npix, refcheck=False)
 
         np.testing.assert_equal(cpp_new_npix, py_new_npix)
+        np.testing.assert_array_equal(cpp_hit_counts, py_hit_counts)
         np.testing.assert_allclose(
             cpp_weighted_counts, py_weighted_counts, rtol=rtol, atol=atol
         )
@@ -153,6 +157,7 @@ class TestComputeWeights(InitCommonParams):
         cpp_sin2phi = np.zeros(self.nsamples, dtype=initfloat.dtype)
         cpp_cos2phi = np.zeros(self.nsamples, dtype=initfloat.dtype)
 
+        cpp_hit_counts = np.zeros(self.npix, dtype=initint.dtype)
         cpp_weighted_counts = np.zeros(self.npix, dtype=initfloat.dtype)
         cpp_weighted_sin_sq = np.zeros(self.npix, dtype=initfloat.dtype)
         cpp_weighted_cos_sq = np.zeros(self.npix, dtype=initfloat.dtype)
@@ -166,6 +171,7 @@ class TestComputeWeights(InitCommonParams):
             self.pointings_flag,
             initfloat.noise_weights,
             initfloat.pol_angles,
+            cpp_hit_counts,
             cpp_weighted_counts,
             cpp_sin2phi,
             cpp_cos2phi,
@@ -177,6 +183,7 @@ class TestComputeWeights(InitCommonParams):
         )
 
         (
+            py_hit_counts,
             py_weighted_counts,
             py_sin2phi,
             py_cos2phi,
@@ -195,6 +202,7 @@ class TestComputeWeights(InitCommonParams):
             comm=brahmap.MPI_UTILS.comm,
         )
 
+        np.testing.assert_array_equal(cpp_hit_counts, py_hit_counts)
         np.testing.assert_allclose(
             cpp_weighted_counts, py_weighted_counts, rtol=rtol, atol=atol
         )
@@ -214,6 +222,7 @@ class TestComputeWeights(InitCommonParams):
         cpp_sin2phi = np.zeros(self.nsamples, dtype=initfloat.dtype)
         cpp_cos2phi = np.zeros(self.nsamples, dtype=initfloat.dtype)
 
+        cpp_hit_counts = np.zeros(self.npix, dtype=initint.dtype)
         cpp_weighted_counts = np.zeros(self.npix, dtype=initfloat.dtype)
         cpp_weighted_sin_sq = np.zeros(self.npix, dtype=initfloat.dtype)
         cpp_weighted_cos_sq = np.zeros(self.npix, dtype=initfloat.dtype)
@@ -229,6 +238,7 @@ class TestComputeWeights(InitCommonParams):
             self.pointings_flag,
             initfloat.noise_weights,
             initfloat.pol_angles,
+            cpp_hit_counts,
             cpp_weighted_counts,
             cpp_sin2phi,
             cpp_cos2phi,
@@ -242,6 +252,7 @@ class TestComputeWeights(InitCommonParams):
         )
 
         (
+            py_hit_counts,
             py_weighted_counts,
             py_sin2phi,
             py_cos2phi,
@@ -262,6 +273,7 @@ class TestComputeWeights(InitCommonParams):
             comm=brahmap.MPI_UTILS.comm,
         )
 
+        np.testing.assert_array_equal(cpp_hit_counts, py_hit_counts)
         np.testing.assert_allclose(
             cpp_weighted_counts, py_weighted_counts, rtol=rtol, atol=atol
         )
@@ -285,7 +297,8 @@ class TestComputeWeights(InitCommonParams):
 
     def test_get_pix_mask_pol_QU(self, initint, initfloat, rtol, atol):
         (
-            weighted_counts,
+            hit_counts,
+            __,
             __,
             __,
             __,
@@ -307,11 +320,13 @@ class TestComputeWeights(InitCommonParams):
         cpp_old2new_pixel = np.zeros(self.npix, dtype=initint.dtype)
         cpp_pixel_flag = np.zeros(self.npix, dtype=bool)
 
+        hit_counts = hit_counts.astype(dtype=initint.dtype)
+
         cpp_new_npix = compute_weights.get_pixel_mask_pol(
             2,
             self.npix,
             1.0e3,
-            weighted_counts,
+            hit_counts,
             one_over_determinant,
             cpp_observed_pixels,
             cpp_old2new_pixel,
@@ -329,7 +344,7 @@ class TestComputeWeights(InitCommonParams):
             self.npix,
             2,
             1.0e3,
-            weighted_counts,
+            hit_counts,
             one_over_determinant,
             dtype_int=initint.dtype,
         )
@@ -341,7 +356,8 @@ class TestComputeWeights(InitCommonParams):
 
     def test_get_pix_mask_pol_IQU(self, initint, initfloat, rtol, atol):
         (
-            weighted_counts,
+            hit_counts,
+            __,
             __,
             __,
             __,
@@ -365,11 +381,13 @@ class TestComputeWeights(InitCommonParams):
         cpp_old2new_pixel = np.zeros(self.npix, dtype=initint.dtype)
         cpp_pixel_flag = np.zeros(self.npix, dtype=bool)
 
+        hit_counts = hit_counts.astype(dtype=initint.dtype)
+
         cpp_new_npix = compute_weights.get_pixel_mask_pol(
             3,
             self.npix,
             1.0e3,
-            weighted_counts,
+            hit_counts,
             one_over_determinant,
             cpp_observed_pixels,
             cpp_old2new_pixel,
@@ -387,7 +405,7 @@ class TestComputeWeights(InitCommonParams):
             self.npix,
             3,
             1.0e3,
-            weighted_counts,
+            hit_counts,
             one_over_determinant,
             dtype_int=initint.dtype,
         )

--- a/tests/test_noise_ops_toeplitz.py
+++ b/tests/test_noise_ops_toeplitz.py
@@ -75,22 +75,22 @@ class NoiseOps_Toeplitz(BaseTestNoiseLO):
         [
             ("operator1", "numpy_operator1"),
             ("operator2", "numpy_operator1"),
-            pytest.param(
-                "inv_operator1",
-                "numpy_inv_operator1",
-                marks=pytest.mark.xfail(
-                    raises=NotImplementedError,
-                    reason=".diag() method is not implemented yet",
-                ),
-            ),
-            pytest.param(
-                "inv_operator2",
-                "numpy_inv_operator1",
-                marks=pytest.mark.xfail(
-                    raises=NotImplementedError,
-                    reason=".diag() method is not implemented yet",
-                ),
-            ),
+            # pytest.param(
+            #     "inv_operator1",
+            #     "numpy_inv_operator1",
+            #     marks=pytest.mark.xfail(
+            #         raises=NotImplementedError,
+            #         reason=".diag() method is not implemented yet",
+            #     ),
+            # ),
+            # pytest.param(
+            #     "inv_operator2",
+            #     "numpy_inv_operator1",
+            #     marks=pytest.mark.xfail(
+            #         raises=NotImplementedError,
+            #         reason=".diag() method is not implemented yet",
+            #     ),
+            # ),
         ],
     )
     def test_diagonal(self, operator, numpy_operator):
@@ -101,6 +101,7 @@ class NoiseOps_Toeplitz(BaseTestNoiseLO):
         np_op = getattr(self, numpy_operator)
 
         op_diag = op.diag
+        print(op, operator)
         np_diag = np.diagonal(np_op)
         np.testing.assert_allclose(
             op_diag,

--- a/tests/test_repixelization_cpp.py
+++ b/tests/test_repixelization_cpp.py
@@ -107,7 +107,14 @@ initfloat64 = InitFloat64Params()
 )
 class TestRepixelization(InitCommonParams):
     def test_repixelize_pol_I(self, initint, initfloat, rtol, atol):
-        new_npix, py_weighted_counts, observed_pixels, __, __ = cw.computeweights_pol_I(
+        (
+            new_npix,
+            py_hit_counts,
+            py_weighted_counts,
+            observed_pixels,
+            __,
+            __,
+        ) = cw.computeweights_pol_I(
             self.npix,
             self.nsamples,
             initint.pointings,
@@ -117,16 +124,27 @@ class TestRepixelization(InitCommonParams):
             comm=brahmap.MPI_UTILS.comm,
         )
 
+        cpp_hit_counts = py_hit_counts.astype(dtype=initint.dtype)
         cpp_weighted_counts = py_weighted_counts.copy()
 
-        repixelize.repixelize_pol_I(new_npix, observed_pixels, cpp_weighted_counts)
-
-        cpp_weighted_counts.resize(new_npix, refcheck=False)
-
-        py_weighted_counts = rp.repixelize_pol_I(
-            new_npix, observed_pixels, py_weighted_counts
+        repixelize.repixelize_pol_I(
+            new_npix,
+            observed_pixels,
+            cpp_hit_counts,
+            cpp_weighted_counts,
         )
 
+        cpp_hit_counts.resize(new_npix, refcheck=False)
+        cpp_weighted_counts.resize(new_npix, refcheck=False)
+
+        py_hit_counts, py_weighted_counts = rp.repixelize_pol_I(
+            new_npix,
+            observed_pixels,
+            py_hit_counts,
+            py_weighted_counts,
+        )
+
+        np.testing.assert_array_equal(py_hit_counts, cpp_hit_counts)
         np.testing.assert_allclose(
             py_weighted_counts,
             cpp_weighted_counts,
@@ -136,6 +154,7 @@ class TestRepixelization(InitCommonParams):
 
     def test_repixelize_pol_QU(self, initint, initfloat, rtol, atol):
         (
+            py_hit_counts,
             py_weighted_counts,
             __,
             __,
@@ -158,11 +177,12 @@ class TestRepixelization(InitCommonParams):
             self.npix,
             2,
             1.0e-5,
-            py_weighted_counts,
+            py_hit_counts,
             py_one_over_determinant,
             initint.pointings.dtype,
         )
 
+        cpp_hit_counts = py_hit_counts.astype(dtype=initint.dtype)
         cpp_weighted_counts = py_weighted_counts.copy()
         cpp_weighted_sin_sq = py_weighted_sin_sq.copy()
         cpp_weighted_cos_sq = py_weighted_cos_sq.copy()
@@ -172,6 +192,7 @@ class TestRepixelization(InitCommonParams):
         repixelize.repixelize_pol_QU(
             new_npix,
             observed_pixels,
+            cpp_hit_counts,
             cpp_weighted_counts,
             cpp_weighted_sin_sq,
             cpp_weighted_cos_sq,
@@ -179,6 +200,7 @@ class TestRepixelization(InitCommonParams):
             cpp_one_over_determinant,
         )
 
+        cpp_hit_counts.resize(new_npix, refcheck=False)
         cpp_weighted_counts.resize(new_npix, refcheck=False)
         cpp_weighted_sin_sq.resize(new_npix, refcheck=False)
         cpp_weighted_cos_sq.resize(new_npix, refcheck=False)
@@ -186,6 +208,7 @@ class TestRepixelization(InitCommonParams):
         cpp_one_over_determinant.resize(new_npix, refcheck=False)
 
         (
+            py_hit_counts,
             py_weighted_counts,
             py_weighted_sin_sq,
             py_weighted_cos_sq,
@@ -194,6 +217,7 @@ class TestRepixelization(InitCommonParams):
         ) = rp.repixelize_pol_QU(
             new_npix,
             observed_pixels,
+            py_hit_counts,
             py_weighted_counts,
             py_weighted_sin_sq,
             py_weighted_cos_sq,
@@ -201,6 +225,10 @@ class TestRepixelization(InitCommonParams):
             py_one_over_determinant,
         )
 
+        np.testing.assert_array_equal(
+            py_hit_counts,
+            cpp_hit_counts,
+        )
         np.testing.assert_allclose(
             py_weighted_counts,
             cpp_weighted_counts,
@@ -234,6 +262,7 @@ class TestRepixelization(InitCommonParams):
 
     def test_repixelize_pol_IQU(self, initint, initfloat, rtol, atol):
         (
+            py_hit_counts,
             py_weighted_counts,
             __,
             __,
@@ -258,11 +287,12 @@ class TestRepixelization(InitCommonParams):
             self.npix,
             3,
             1.0e-5,
-            py_weighted_counts,
+            py_hit_counts,
             py_one_over_determinant,
             initint.dtype,
         )
 
+        cpp_hit_counts = py_hit_counts.astype(dtype=initint.dtype)
         cpp_weighted_counts = py_weighted_counts.copy()
         cpp_weighted_sin_sq = py_weighted_sin_sq.copy()
         cpp_weighted_cos_sq = py_weighted_cos_sq.copy()
@@ -274,6 +304,7 @@ class TestRepixelization(InitCommonParams):
         repixelize.repixelize_pol_IQU(
             new_npix,
             observed_pixels,
+            cpp_hit_counts,
             cpp_weighted_counts,
             cpp_weighted_sin_sq,
             cpp_weighted_cos_sq,
@@ -283,6 +314,7 @@ class TestRepixelization(InitCommonParams):
             cpp_one_over_determinant,
         )
 
+        cpp_hit_counts.resize(new_npix, refcheck=False)
         cpp_weighted_counts.resize(new_npix, refcheck=False)
         cpp_weighted_sin_sq.resize(new_npix, refcheck=False)
         cpp_weighted_cos_sq.resize(new_npix, refcheck=False)
@@ -292,6 +324,7 @@ class TestRepixelization(InitCommonParams):
         cpp_one_over_determinant.resize(new_npix, refcheck=False)
 
         (
+            py_hit_counts,
             py_weighted_counts,
             py_weighted_sin_sq,
             py_weighted_cos_sq,
@@ -302,6 +335,7 @@ class TestRepixelization(InitCommonParams):
         ) = rp.repixelize_pol_IQU(
             new_npix,
             observed_pixels,
+            py_hit_counts,
             py_weighted_counts,
             py_weighted_sin_sq,
             py_weighted_cos_sq,
@@ -311,6 +345,10 @@ class TestRepixelization(InitCommonParams):
             py_one_over_determinant,
         )
 
+        np.testing.assert_array_equal(
+            py_hit_counts,
+            cpp_hit_counts,
+        )
         np.testing.assert_allclose(
             py_weighted_counts,
             cpp_weighted_counts,
@@ -367,12 +405,13 @@ class TestRepixelization(InitCommonParams):
 class TestFlagBadPixelSamples(InitCommonParams):
     def test_flag_bad_pixel_samples(self, initint, initfloat):
         (
-            py_weighted_counts,
+            py_hit_counts,
             __,
             __,
-            py_weighted_sin_sq,
-            py_weighted_cos_sq,
-            py_weighted_sincos,
+            __,
+            __,
+            __,
+            __,
             __,
             __,
             py_one_over_determinant,
@@ -391,7 +430,7 @@ class TestFlagBadPixelSamples(InitCommonParams):
             self.npix,
             3,
             1.0e-5,
-            py_weighted_counts,
+            py_hit_counts,
             py_one_over_determinant,
             initint.dtype,
         )


### PR DESCRIPTION
This PR changes how the pathological pixels are identified and flagged. Earlier, we were using the following two criteria:
1. Comparing the determinant of the blocks of $P^tN^{-1}P$ for each pixel against zero.
2. Comparing `weighted_counts` against count threshold (given by `SolverType - 1`)

We have updated them as follows:
1. Comparing the absolute value of the determinant of the blocks of $P^tN^{-1}P$ for each pixel against zero.
2. 2. Comparing `hit_counts` against count threshold (given by `SolverType - 1`)