### PR TITLE
Adding Google Colab links for the notebook examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,22 +12,22 @@ open an [issue](https://github.com/anand-avinash/BrahMap/issues/new).
 
 ## Jupyter notebooks
 
-- [`rectangular_I_map_explicit.ipynb`](rectangular_I_map_explicit.ipynb)  
+- [`rectangular_I_map_explicit.ipynb`](rectangular_I_map_explicit.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/rectangular_I_map_explicit.ipynb)]  <!-- markdownlint-disable MD013 -->  
   This example presents the GLS map-making for $I$ component over a
   rectangular map, using the linear operators explicitly. Its workflow can be
   modified to compute the maps in different ways.
 
-- [`healpix_QU_map_wrapper.ipynb`](healpix_QU_map_wrapper.ipynb)  
+- [`healpix_QU_map_wrapper.ipynb`](healpix_QU_map_wrapper.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/healpix_QU_map_wrapper.ipynb)]  <!-- markdownlint-disable MD013 -->  
   This notebook presents the GLS map-making for $Q$ and $U$ components over a
   healpix map, using the dedicated wrapper function for the same.
 
-- [`lbsim_IQU_map_explicit.ipynb`](lbsim_IQU_map_explicit.ipynb)  
+- [`lbsim_IQU_map_explicit.ipynb`](lbsim_IQU_map_explicit.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/lbsim_IQU_map_explicit.ipynb)]  <!-- markdownlint-disable MD013 -->  
   This notebook presents the GLS map-making for $I$, $Q$ and $U$ components
   using a typical simulation from *LiteBIRD* simulation framework. The example
   uses the linear operators explicitly, and its workflow can be modified to
   compute the maps in different ways.
 
-- [`lbsim_IQU_map_wrapper.ipynb`](lbsim_IQU_map_wrapper.ipynb)  
+- [`lbsim_IQU_map_wrapper.ipynb`](lbsim_IQU_map_wrapper.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/lbsim_IQU_map_wrapper.ipynb)]  <!-- markdownlint-disable MD013 -->  
   This notebook presents the GLS map-making for $I$, $Q$ and $U$ components
   using a typical simulation from *LiteBIRD* simulation framework. The example
   uses the dedicated wrapper function for GLS map-making from `litebid_sim`
@@ -65,15 +65,15 @@ the white noise covariance used in these examples. The following example
 notebooks provide an overview of the available noise covariances and
 demonstrate various methods for creating them.
 
-- [`basic_noise_covariances.ipynb`](basic_noise_covariances.ipynb)  
+- [`basic_noise_covariances.ipynb`](basic_noise_covariances.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/basic_noise_covariances.ipynb)]  <!-- markdownlint-disable MD013 -->  
   This notebook contains the examples related to the basic noise covariance
   operators.
 
-- [`block_diagonal_noise_covariances.ipynb`](block_diagonal_noise_covariances.ipynb) <!-- markdownlint-disable MD013 -->  
+- [`block_diagonal_noise_covariances.ipynb`](block_diagonal_noise_covariances.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/block_diagonal_noise_covariances.ipynb)] <!-- markdownlint-disable MD013 -->  
   This notebook contains the examples for the block-diagonal noise covariances
   that corresponds to a noise time-stream made up of multiple stationary but
   mutually uncorrelated sections.
 
-- [`lbsim_noise_covariances.ipynb`](lbsim_noise_covariances.ipynb)  
+- [`lbsim_noise_covariances.ipynb`](lbsim_noise_covariances.ipynb) [[open in Colab](https://colab.research.google.com/github/anand-avinash/BrahMap/blob/main/examples/lbsim_noise_covariances.ipynb)]  <!-- markdownlint-disable MD013 -->  
   This notebook contains the examples for the noise covariance operators for
   the BrahMap's interface to `litebird_sim`.

--- a/examples/basic_noise_covariances.ipynb
+++ b/examples/basic_noise_covariances.ipynb
@@ -38,6 +38,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "6ff233a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "6e3c5f1d",
    "metadata": {},

--- a/examples/block_diagonal_noise_covariances.ipynb
+++ b/examples/block_diagonal_noise_covariances.ipynb
@@ -44,6 +44,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "d293b38b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "8732ca9b",
    "metadata": {},

--- a/examples/healpix_QU_map_wrapper.ipynb
+++ b/examples/healpix_QU_map_wrapper.ipynb
@@ -11,6 +11,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib healpy git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [

--- a/examples/lbsim_IQU_map_explicit.ipynb
+++ b/examples/lbsim_IQU_map_explicit.ipynb
@@ -11,6 +11,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib healpy litebird_sim git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [

--- a/examples/lbsim_IQU_map_wrapper.ipynb
+++ b/examples/lbsim_IQU_map_wrapper.ipynb
@@ -11,6 +11,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib healpy litebird_sim git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [

--- a/examples/lbsim_noise_covariances.ipynb
+++ b/examples/lbsim_noise_covariances.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "f2e145d9",
    "metadata": {},
    "outputs": [],
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "58ecb489",
    "metadata": {},
    "outputs": [
@@ -75,19 +75,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "20091246",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<litebird_sim.observations.Observation at 0x7f14a42b8290>,\n",
-       " <litebird_sim.observations.Observation at 0x7f1498be3f10>,\n",
-       " <litebird_sim.observations.Observation at 0x7f1498be83d0>]"
+       "[<litebird_sim.observations.Observation at 0x7fb07f08f6d0>,\n",
+       " <litebird_sim.observations.Observation at 0x7fb07da4fa10>,\n",
+       " <litebird_sim.observations.Observation at 0x7fb07da4fe90>]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "5141f6f6",
    "metadata": {},
    "outputs": [
@@ -155,19 +155,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-06-27 20:45:40,533 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,535 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,537 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,538 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,540 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,542 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,543 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,544 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:40,545 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:40,546 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:40,547 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:40,548 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:40,549 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+      "[2025-07-01 11:32:46,024 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,026 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,026 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,027 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,027 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,027 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,027 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,028 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,028 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,028 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,029 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,029 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,029 INFO MPI#0000] New linear operator with shape (284, 284)\n"
      ]
     },
     {
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "69c8979d",
    "metadata": {},
    "outputs": [
@@ -214,19 +214,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-06-27 20:45:42,192 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,194 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,196 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,198 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,199 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,201 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,202 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,203 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:42,205 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:42,207 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:42,208 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:42,209 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:42,210 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+      "[2025-07-01 11:32:46,269 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,270 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,271 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,271 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,271 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,272 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,272 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,272 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,273 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,273 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,274 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,274 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,275 INFO MPI#0000] New linear operator with shape (284, 284)\n"
      ]
     },
     {
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "9fa4c214",
    "metadata": {},
    "outputs": [
@@ -309,19 +309,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-06-27 20:45:43,911 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,912 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,914 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,915 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,916 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,920 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,921 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,923 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:43,925 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:43,927 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:43,928 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:43,933 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:43,935 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+      "[2025-07-01 11:32:46,480 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,480 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,481 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,482 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,482 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,483 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,484 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,484 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,485 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,485 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,486 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,486 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,487 INFO MPI#0000] New linear operator with shape (284, 284)\n"
      ]
     },
     {
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "df9e684b",
    "metadata": {},
    "outputs": [
@@ -375,19 +375,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-06-27 20:45:44,585 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,588 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,589 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,591 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,593 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,594 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,596 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,599 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:44,601 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:44,603 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:44,605 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:44,606 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:44,608 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+      "[2025-07-01 11:32:46,623 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,625 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,625 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,626 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,626 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,626 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,627 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,627 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,628 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,628 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,628 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,628 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,629 INFO MPI#0000] New linear operator with shape (284, 284)\n"
      ]
     },
     {
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "f298cc19",
    "metadata": {},
    "outputs": [
@@ -450,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "e2570fd0",
    "metadata": {},
    "outputs": [
@@ -513,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d59ebe4c",
    "metadata": {},
    "outputs": [
@@ -521,31 +521,31 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-06-27 20:45:45,450 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,452 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,455 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,456 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,458 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,459 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,461 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,463 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,465 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,466 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,468 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,470 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,472 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,473 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,475 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,476 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:45,477 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,479 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,480 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,482 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,484 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,486 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,490 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,491 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:45,493 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+      "[2025-07-01 11:32:46,872 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,873 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,873 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,874 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,874 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,875 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,875 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,876 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,876 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,876 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,877 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,877 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,877 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,877 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,878 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,878 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:46,879 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,879 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,880 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,880 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,881 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,881 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,882 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,882 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:46,883 INFO MPI#0000] New linear operator with shape (284, 284)\n"
      ]
     },
     {
@@ -589,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "9c2e3064",
    "metadata": {},
    "outputs": [
@@ -597,31 +597,31 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-06-27 20:45:58,437 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,438 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,439 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,440 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,442 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,444 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,446 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,447 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,449 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,450 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,454 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,455 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,457 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,458 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,460 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,462 INFO MPI#0000] New linear operator with shape (24, 24)\n",
-      "[2025-06-27 20:45:58,465 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,466 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,469 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,470 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,473 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,474 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,476 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,477 INFO MPI#0000] New linear operator with shape (23, 23)\n",
-      "[2025-06-27 20:45:58,478 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+      "[2025-07-01 11:32:50,305 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,306 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,306 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,306 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,306 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,307 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,307 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,307 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,308 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,308 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,308 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,308 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,309 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,309 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,309 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,309 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,309 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,310 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,310 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,310 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,310 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,310 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,311 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,311 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,311 INFO MPI#0000] New linear operator with shape (284, 284)\n"
      ]
     },
     {
@@ -655,6 +655,122 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8f71e31d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2c319fb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5b2b29c",
+   "metadata": {},
+   "source": [
+    "### Inverse noise covariance with different types of covariance blocks for different observations and detectors\n",
+    "\n",
+    "In this example, we demonstrate creating the inverse noise covariance operator with different types of covariance block for each observation and detector. To do this, we must define each block operator individually and pass them together as a list to the base class for block-diagonal noise operator. In this particular example, we are using inverse diagonal covariance for each block, but an user can follow the same to use different covariance types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "82414c39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(seed=3434)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2dcf71f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-07-01 11:32:50,687 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,688 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,688 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,688 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,689 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,689 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,689 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,689 INFO MPI#0000] New linear operator with shape (24, 24)\n",
+      "[2025-07-01 11:32:50,690 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,690 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,690 INFO MPI#0000] New linear operator with shape (23, 23)\n",
+      "[2025-07-01 11:32:50,690 INFO MPI#0000] New linear operator with shape (23, 23)\n"
+     ]
+    }
+   ],
+   "source": [
+    "### Creating a list of inverse diagonal noise covariance operators\n",
+    "\n",
+    "list_ops = []\n",
+    "\n",
+    "for obs in sim.observations:\n",
+    "    for det_idx in range(obs.n_detectors):\n",
+    "        inv_op = brahmap.InvNoiseCovLO_Diagonal(\n",
+    "            size=obs.n_samples,\n",
+    "            input=rng.random(1)[0],  # random variance for each operator\n",
+    "            input_type=\"covariance\",\n",
+    "            dtype=np.float32,\n",
+    "        )\n",
+    "        list_ops.append(inv_op)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0d6f3778",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2025-07-01 11:32:50,695 INFO MPI#0000] New linear operator with shape (284, 284)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcwAAAGOCAYAAAAaSzPhAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAM4JJREFUeJzt3Xl8VPW9N/DPb2Yyk21mspAQkgyLCIbFDbe63F5tufW69Grv08V78ZZLS+1t8arleWotT12qFWof6oUuD1jbqr2i1dZql6f1VlG0XhDZBFEhEAIZErKQZJZMklnO+T1/jKFEI2SYs805n7ev88qLgZzv92RkvvyW8z1CSilBREREJ+QyOwEiIqJCwIJJREQ0DiyYRERE48CCSURENA4smEREROPAgklERDQOLJhERETjwIJJREQ0Dp7x/CFVVdHR0QG/3w8hhN45ERGRxqSUiMfjqK+vh8ulz1hpeHgYqVRKk3N5vV4UFxdrci6tjKtgdnR0IBQK6Z0LERHpLBwOo7GxUfPzDg8PY9qUcnR2K5qcr66uDq2trZYqmuMqmH6/HwDw70sfRGd8CJ7eYZS0RHVNbETDzHr8r59+BSsXr0F7c4chMa0Q2+z4jM33nHHtFTelJPH47oeOfZ5rfv5UCp3dClq3TUHAn98INhZXMe28Q0ilUoVXMEemYRPrD+Iwkoh8LIS6F3rgGkxDqLrmB6/bh0AggJ6WXrTtMvYDxMzYZsdnbL7njGuvuBmZBgDdl9UCflfeBdOqxlUwj1e2qxfFLTGEv3k+6n+4E96uQT3yIiKiAqRIFUqej/RQpM4jsVN0Sv8McA2lUf/DN9F/5RTEPlKndU5ERFSgVEhNDis6pYIpVMDbNYSS5n6opR7ELpqodV5ERESWktdEc+D1TrgH0hicXY10TQmkPaetiYhonFSN/rOivEuc/40uVP/+ANpvPQdKeZEWORERUYFSpNTksCJNxoSevmE0PrAVXQtnY+CcCVqckoiIaFxeffVVfPKTn0R9fT2EEHjuuedG/b6UEnfddRcmTZqEkpISzJ8/H/v27cs5jiYFU6iAJ55G8C/tSNeUIHpZvRanJSKiAmPGpp9EIoGzzz4bP/7xj8f8/e9973v4wQ9+gLVr12Lz5s0oKyvDlVdeieHh4Zzi5HxbyYmUv3kU0UsnIV1XhuGpAfgOxSCsObImIiIdqJBQ8tzlmmvBvOqqq3DVVVeN+XtSSqxatQrf+ta3cN111wEAfvGLX2DixIl47rnncMMNN4w7jubbdIL/fQTlW7vQtXAW1GI3JFvPEhE5hpYjzFgsNupIJpM559Pa2orOzk7Mnz//2GvBYBAXXXQRNm3alNO5dNnX6muLI/TAVrR/7VwMz6jQIwQREdlcKBRCMBg8dqxYsSLnc3R2dgIAJk4cffvjxIkTj/3eeGk6JTtCSABJBTW/2o/BpkqkJpYi+Bfj24wREZGxtNjlOvL94XAYgUDg2Os+ny+v8+ZLtzsnhQRK9kXgiSShlBchMafKor0biIhIK6pGBwAEAoFRx6kUzLq6bDe6rq6uUa93dXUd+73x0r3VQPAvHfAdiqP/qqlQSz1sbkBERIaZNm0a6urqsH79+mOvxWIxbN68GRdffHFO59JlSvb9St/pQ/HBGMJ3nI9Ja9+CryNhRFgiIjKYosEu2Vy/f2BgAPv37z/269bWVrz55puoqqrC5MmTcdttt+E73/kOZsyYgWnTpuHOO+9EfX09rr/++pziGFIwBQDXcAaT1r6F6OWNKD4YQ2DjESNCExGRgRQJDZ5Wktuf37p1K6644opjv166dCkAYOHChXj00Udx++23I5FI4KabbkIkEsFll12G559/PudnbRpSMIFscwNfRwLFrTGopR7Ez6+Ff2u3UeGJiMimLr/8csgTbDQSQuDee+/Fvffem1ccw1cUA5uOwB1NYmBeLdJVPq5pEhHZiJabfqzGlHLl39qNCb/eh/b/OQ9KwNxtwkREpB0VAkqehwprdrwxbXzniSTR+H+2o/uGmYifV2tWGkRERONiWsEUarZo+t/oRKbCh+ilk8xKhYiINKJKbQ4rMn0F0b+9B+6hDFIhP5KN5ew9S0RUwPKdjh05rMj0ggkAgY1HEHitA51fmgu12MOOQEREBYoF0wDe9gE0fncrOv79bAzNqjI7HSIiolEMuw/zZIQEXEMZVP/+AIanBZGeUMyG7UREBUaVAmqea2v5fr9eLFMwgWxHoNJ3+5GeUIJMwIvBMyo5PUtEVEC0mFLllGwOgn/pQMn+KHo/NR2y2G12OkRERNYaYR6vZG8/6lfvQNd/XG12KkRENE4KXFDyHIspGuWitZwKZsPMenjdxnXmkQKYtHsIANB4ySzD4o4INTWM+uqk+IzN95xx7RU3pSSxYaf+caQGa5jSomuYQp6oY+17YrEYgsEgotHoqKdfExFRYdD7c3zk/Ovfmowyf34jzERcxcfPbLNczclphLly8Rr0tPTqlcuYQk0NWLbuVty/5KcIR1NAy2GIdAZG7AYaib18wWqE97TrH9BC8Rmb7znj2ituSkkaEsfOm35yKpjtzR1o22XOrR6HX2/G/ncOQ734TLh2vQ0xZMybDwDhPe3Yv6PVsHhWis/Y5nDitTOuvjIybUgcRbqg5PkYqnyfp6kXS+6S/TAilYZr89uQZ0yGrJ9gdjpEROQglt0lOyaJ7Miyqx/SVwQ01EC095idFRERvUeFgJrnWEy16B34BTXCHCGOHIVIZyAr/ZDlJbDodDcRkePYuZdsYY0wjyPae4DoANTzmuDa+FZ2IxAREZlKmzVMjjA1JxJDcG18C+q8MyBrKsxOh4iIbKxgR5gAsmua6QxcB9oh/WWQxT64wl1mZ0VE5FjZNcw8m69zSlY/oicCWewFSnyQlX6I/rjZKREROZKqQWs8bvrRmSvcDdETgTp7GqSHDduJiEhbthhhjhD9cbg2vw31I3Ph2t0CERkwOyUiIkex86YfWxVMABAZBa7dLZATqyD9pXCFu81OiYjIMVS4eB9mIRGRAWBwGPB4IGsrzU6HiIhswHYjzBGucDdkbSXklDogEjesYTsRkZMpUkDJ8/Fc+X6/XmxbMAFAdPcDkXi2YfvWdyESw2anRERka9o8QNqaoxtbTskeT6QzcG19F3J6I2RDjdnpEBFRgbL1CBNAtrlBYhg4GoH0smE7EZGeVOmCmucuWZW7ZM0lOo4C9RMgJ1QA/XGIoWGuaRIRaczOU7KOKZjAe0UzMgD1gtlwbdoFkWLDdiIiLanIf9OOqk0qmrP9Gub7iaFhuDbtgjx7BuTEKrPTISKiAuGoESaA7JpmKgMc6oQsK4EM1bK5ARGRRrRpXGDNsZzzCuZ7RHc/ZKgIKCuBrChnGz0iIg1o0xrPmgXTmlkZxBXuhujshXrmdDZsJyKiE3J0wQSybfRcm3ZDvWgOZFXA7HSIiArayPMw8z2syLFTsscTGQWud1ohJ1RAlpXwIdRERKeIU7IOIPrjwHASKPJA1lSYnQ4REVkMR5jHcYW7IWsqoJ7WAFdkABadFSAisixtGhdYcyzHgvk+oicCVyQO9ZKzIDNDZqdDRFRQVCmg5tu4wKJPK7FmGTeZyChwbdsD1E8wOxUiIrKInEaYDTPr4XX79MplTKGmhlFfjdRY4wcAXLooCGCa4fHNvHbGNj622fHNis24xkgpSWzYqX8cVYMpWas2LhBSnrwtfCwWQzAYRDQaRSDAWy+IiAqN3p/jI+df/sYVKC7Pb7VveCCDZRe+bLmak9NVrVy8Bj0tvXrlMqZQUwOWrbsVyxesRnhPuymxV9/yfVxw+0b8ZvFkJHo8MGo3kBWunbGN5cRrZ1xjpJSkIXEUCCh5fkbm+/16yalgtjd3oG1Xh165nFB4Tzv272g1Jfbe1zvxykUKrvu/r2LH45V4+5lKQ+Obee2MbQ4nXjvj6isj04bFsitrThRbjFQE4kc82PF4JSpCaZz3BWNH2UREhWLkAdL5HlZkzawsSeDtZyoxHHOj7qwhTDp3EMJtzYecEhGZRcFfp2VP/bAmFswcbft5NbY/WoXPPn4QvnIFECyaREROwIJ5Cjp3lWDtJWdg4Z9aMP1jfCwYEdEIO0/JstPPKZCqQDLmwovfqsfkSwZQNT2JLT9hkwMiIjZfpw+SAi0v+THQVYTy2gymz49xepaIyMZYMPO05eEJaNtYhvnfPoLigALhYtEkIueSGjwLU1r0PkwWTA20vFyOx64+Hf+2qRl1Z7FhOxE518iUbL6HFVkzq0IjBZJxF57656mY9699vE+TiMiGWDA1IlWBI2+WonNnCYoDCuZ+uh8Ap2eJyFlGHu+V72FFLJga2/ZINSLhIpy9oB/++jSbGxCRo4w8QDrfw4qsmVWBe/uZCvxuSQg3vboPwQb2byQi5+AIk3IkMNDlwc8+NgN//712nHVDv9kJERFRnlgwdSIVgUibF28/W4HyiWnM+1duBCIi+1Ph0uSwImtmZSNvPVWJoYgboYsSqJ0zxDVNIrI1RQpNjpxiKgruvPNOTJs2DSUlJZg+fTruu+8+SKnt5y1b4xlgx2PVaN9aigXPtGLtxTMx1O+GUQ+hJiKyuwceeABr1qzBY489hjlz5mDr1q1YtGgRgsEgbrnlFs3isGAapGdPMdZePBMLftOKVx+oRfPzQbNTIiLSnBabdnL9/o0bN+K6667DNddcAwCYOnUqnnzySbzxxht55fF+nJI1iFQEhvrdeOW7E1F3zhAu+NJRs1MiItKc1OBJJTLHTj+XXHIJ1q9fj+bmZgDAzp078dprr+Gqq67S9No4wjSUwL7/CiA4OYVgYxpTPzqAg38pAyy6hZqIyEyxWGzUr30+H3w+3wf+3B133IFYLIampia43W4oioL7778fCxYs0DQfjjBNsPXhCWh50Y+rv38YPr/Khu1EZBsKhCYHAIRCIQSDwWPHihUrxoz59NNPY926dXjiiSewfft2PPbYY1i5ciUee+wxTa+NI0yTHHytDD/7+Ax8+bVm/GbxZBx+o8zslIiI8qbK3NcgxzoHAITDYQQCgWOvjzW6BICvf/3ruOOOO3DDDTcAAM4880wcOnQIK1aswMKFC/PK5XgsmGaRAqkBF37zxcmY++kI6s4awtaf8iHUREQjAoHAqIL5YQYHB+FyjZ4wdbvdUFVV03xYME0kVYHDW8pQd9YQiisUzLougnd/GwRvOSGiQjWycSffc+Tik5/8JO6//35MnjwZc+bMwY4dO/Dggw/iC1/4Ql55vB8LpgVs/dkEzLouggu/fBRtm8ow2OuBVFg0iajwjDwEOt9z5OKHP/wh7rzzTnz1q19Fd3c36uvr8eUvfxl33XVXXnm8HwumRbz72yDaNpbh3zY249GrTkfv/rHn6omIrOxUOvWMdY5c+P1+rFq1CqtWrcor7slwl6xlCAz2efDI35+OK+7sxDkL+sxOiIiIjsMRpoVIRaCvxYd9f/ajtDqDhmtiJ/8mIiILMWMN0yjWzMrhdq6rwlC/B5POHTI7FSKinKjQ4HmYFt34mNMIs2FmPbxuY9fWQk0No746JfbA7mloEVOATwGh2SHD4zv1525mbLPjmxWbcY2RUpLYsNPQkLYj5DiefxKLxRAMBhGNRsd1TwwREVmL3p/jI+f/zPrPo6jMm9e50okUfvXxX1iu5uQ0wly5eA16Wox9EHKoqQHL1t2K5QtWI7yn3TGxR8W/6SEcPtQPqApkX9TY2A77uVvmPXfQtTOuMVJK0pA4ZjytxCg5Fcz25g607erQK5cTCu9px/4drY6LDQDhbS1oaY8BxT7IvggwMGhcbIf+3E1/zx147Yyrr4xMGxbLrrhLtkDI7l6gvBSuaZOhvtMMKNq2fCIi0gJ3yZI1DAxCfacZrtkzAD+btROR9eS9Q1aDKV29sGAWGkWFevAwREUAorba7GyIiByDU7KFKJ4ASooBjxuoCAARNjggImswo5esUVgwC5Ts7gUqAhCTaiEHEkBGMTslIiLukiWLisQgBxJwzZkJtfkAMGTMtnEiog9j54LJNcxCl1GgNh+AqKsFaqrMzoaIyLY4wrSDoSTkQALC7YasrgR6+83OiIgcys4jTBZMu+jpg6yuhKgMZNc0UyngpE0PiYi0ZeeCySlZO+nthwwfgWvW6YCH/xYiItISP1XtJpWC+nYzxGmTIXt6AYN6zxIRAdmJrXxvC7Hq5BgLpt1IAOkMZE8vhM8L1FRB9vSZnRUROQSnZKnw9EWz92aWlgBlJWZnQ0RU8FgwbUz29EEe7YNr+hTAzbeaiPRn516ynJK1u8RQdk1z1umQbR1AbMDsjIjIxjglS4VNUSHbOiD85WzYTkR0ijjCdIrYAFDsA4o8QNAPRONmZ0RENmTnESYLpoPI7l4g6IdorIMcGAQUNmwnIm1JKSDzLHj5fr9eWDCdJhqHHBiEa+5MqPsOAoNDZmdERDZi58d7cQ3TiRQF6r6DELXVEGzYTkQ0LhxhOtXgEJAYBNxuoKoC6IuYnRER2YCd1zA5wnQw2dMHmUpDTKgEvEWw6CwIERWQkTXMfA8rYsF0ur4I5MHDcM2eARQVmZ0NEZFlcUqWgHQa6jv7IKY0QPZFgN6I2RkRUYGy85QsCyZlG7an0pB9EYiiIoAbgYjoFNn5thJOydJf9Uay92aWlwLFXrOzISKyFI4waRTZ0wcMDMJ14UyzUyGiAiQ1mJK16ggzp4LZMLMeXrdPr1zGFGpqGPXVKbHNjt/gSWdjnzfd8Nh8z5117YxrjJSSxIad+seRAGSeT4C26gOkhZQnv7RYLIZgMIhoNIpAIGBEXkREpCG9P8dHzn/ur5fCXZrfwEoZTGLHpx+0XM3JaYS5cvEa9LT06pXLmEJNDVi27lYsX7Aa4T3tjoltdvxjsZf8HOG2XiCWAAYGjY3N99wRsRnXGCklaUgcFQLCpq3xciqY7c0daNvVoVcuJxTe0479O1odF9vs+OHX92D/gaPA9EZgV5uhDdv5njvr2hlXXxmZNiQOd8mSs0XjwM5m4NwmwF9qdjZEZGEj92Hme1gRCyaNj6IAe1uBmmqgboLZ2RARGY4Fk8YvPpht2u5xA9UVZmdDRBYkpTaHFfE+TMpN59FssZxUA8QGgEzGunvAichwXMMkOl5vJDs9e+4swGfsfblERGbhCJNOTSYD7GoGptYDfVGgu8/sjIjIAuw8wmTBpFMjAQwns8WyyANMrAa6jL1Hl4isR5UCwqZPK+GULOWnuw/IKEDQD5QU8yHURGRbLJiUv65eINwJnDkD8HDSgsjJ7LxLlgWTtDE8DOx4F5h1GlAdNDsbIjJJtuCJPA+zr2JsLJikDQkgnQHau4DSEmASmxsQkb1w/oy01RsFvEVAsQ8IlGfv1SQix7DzLlmOMEl7R45mC+eMKYCb/4sROYnU6LAifpqRPmIDwJvvAuc0ZUeaROQI+a9f5j9C1QsLJulHUYF9bdlNQFzTJKICx4JJ+ooNZBsceDxAFXfPEtmejedkuemH9HfkaLZYNtZlC6iiWPYvBBHlSYspVU7JkqP1RYF39gPzZmc7AhERFRiOMMk4igLs3pcdaUbj7D1LZENadOqxauMCFkwyjgQwOJwtlh4PUFvFp5wQ2QzvwyTSUlcvkE4DVRVAsZcN24moILBgkjm6+4CDh4Gzzsg+HoyI7EEKbQ4LYsEk8yRT2eYGM6cBEyrMzoaINMCnlRDpQQJIZYDOnmzv2To2NyAqeCbdh9ne3o4bb7wR1dXVKCkpwZlnnomtW7fmfTnH41wYme9oJFssy0qA8lKzsyGiAtPf349LL70UV1xxBf70pz+hpqYG+/btQ2VlpaZxWDDJGjqPZotl02kAhszOhohOkRm7ZB944AGEQiE88sgjx16bNm1aXjmMhVOyZB0Dg9mHUM+YYnYmRJQPjaZjY7HYqCOZTI4Z7ne/+x3OP/98fOYzn0FtbS3OPfdcPPzww5pfVk4jzIaZ9fC6fZoncSKhpoZRX50S2+z4psYuyf47ruozc3C60bH5nhsem3GNkVKS2LDT0JB5C4VCo359991345577vnAnztw4ADWrFmDpUuXYtmyZdiyZQtuueUWeL1eLFy4ULN8hJQn348Ui8UQDAYRjUYRCAQ0C05ERMbQ+3N85Pyhh+6GK8/2l+rQMMJf/jbC4fCoXH0+H3y+Dw7avF4vzj//fGzcuPHYa7fccgu2bNmCTZs25ZXL8XIaYa5cvAY9Lca2Mws1NWDZuluxfMFqhPe0Oya22fGtEPuub/4UO08XqHtkP0RSgVCNi8333LjYjGuMlDL2dKbmtHjayHvfHwgExlXcJ02ahNmzZ496bdasWXjmmWfyTGS0nApme3MH2nZ1aJrAeIX3tGP/jlbHxTY7vpmxu//cjPiPwti5/FyEvv8OitsShsXme258bMbVV0amDYtltEsvvRR79+4d9VpzczOmTNF2PwQ3/ZBlCQCuoQxC338H/Z+oR/8VdWanREQnJTQ6xu9rX/saXn/9dSxfvhz79+/HE088gZ/85CdYsmSJNpf0HhZMsjShAsVtCRS3xKGWuhG9uMbslIjoRExoXHDBBRfg2WefxZNPPom5c+fivvvuw6pVq7BgwQJNLmkE78OkglD5cieiF9cgdkkNSptj8PQnDVnTJKLCcO211+Laa6/VNQZHmFQwgpt6UPdoCw7eew4yFV6z0yGisZjUGs8ILJhUUDz9SUy9cwc6vzAD0Us4PUtkOXxaCZE1CBUo6kshsLEbmUovNwIRWQyfVkJkMcGNPXANKhg+rRzDU8og+X8yEemMHzNUsCpf7kTli0cQXjobaonHqsseRM7CNUwia/KFEzht2Q603TEXibO1fZQPEZ0CrmESWZNQAVcig5pfH8LQdD/6508yOyUisikWTCp4AkD5zn54YmmkK71IzK2w6j9QiWxPSG0OK2LBJNuofPEIyt6NomvBaVBL3CyaRGbgGiZRYSh9O4Ip9+1E6/3nYnhaudnpEJGNsGCSrQgJuIYUNPxwD6J/MxH9H+N9mkSG4qYfosIhJFByYAC+cAJqqQexiyaYnRKRc3BKlqjwVL7UiaKeYUQ+VodMRRGbGxBRXvgRQrYW2HwU9Wv2ovU785CeUGx2OkT2xxEmUeFyx9KYcu9OdP/TNEQvqzU7HSJ7Y8EkKlxCBbzdw/Bv60UmUITI5RPNTonIvrjph6jwBV/rhnswg8GmIJINpVzTJKKc8CODHKViQxeqf38YbXfMhVLmMTsdItthpx8iG/EeGcS0ZdtxeOlsxOdVmZ0Okb1wDZPIPoQKeOIZVP/+MJKTy9iwnYjGhQWTHMu/vQ/ugQxSNcUYPCNg1X0GRGQRLJjkaJUvHoF/ey+OLJ4BtZgN24nyJaDBGqbZF/EhWDDJ8UqaY5h615s4eN85SE4pMzsdIrIoFkxyPCEB17CCST/Zh8FZFWanQ1TYbHwfZk776htm1sPr9umVy5hCTQ2jvjolttnxnRq7qrQCADD5nNMMjw048+fOuMZIKUls2GlAIC12uVp0l6yQUp40tVgshmAwiGg0ikAgYEReRESkIb0/x0fOP2XF/XAV59e3WR0exqFv/m/L1ZycRpgrF69BT0uvXrmMKdTUgGXrbsXyBasR3tPumNhmx3d87H/5ATpiKpSubiCdMT6+g37ujGuMlJI0JpCNR5g5Fcz25g607erQK5cTCu9px/4drY6LbXZ8x8Z+5zD2v30YrqoqyMFByFjc2PgO/Lkzrr4yMm1IHC069bDTD1GhSaUhBwch3G6IgN/sbIgKAzv9EDmTjMUhFQWuslKgqMjsdIjIRCyYRCchY3EoR/vgCTUAbrfZ6RBZG0eYRA6XTiNzKAz3pIkQ5WxuQPRh+LQSIgIUBWokCuEtgghaZ6s7ERmDBZMoB3IgAamoED4vRLGxTTyICoKNO/2wYBLlSEZjkLE4XJPqABf/ChGNwjVMIjqeHE5CORSGe3IDRGmJ2ekQkQFyalxARMdRVajdRyFKSwGvFzISNTsjItOxcQERjUkODkFm0hBuF0RZqdnpEJmPU7JE9GFkJAY5nISruoprmkQ2xilZIg3IxCCUoWG4p06G0t4BJFNmp0RkDi3uo+QIk8jmVBVKewdcFRW8T5Oci1OyRDQuyRTk8DCEywXhLzc7GyLjsWAS0XjJaAwyk4HL7wc8XPUgsgsWTCIdyPgAlO4eeCY3Ah42bCfnYC9ZIspdJoNMWxjuibWcniWyARZMIj1lFKixOITHw41ARAWOBZNIZzI+AKmq2WbtPq/Z6RDpi5t+iCgfMhqDGonCXT+JzQ3I1riGSUT5S6ayDdtDDWyjR1SAuOedyEiqCrWnF6KkGCgqYsN2sieLjhDzxREmkcHk4CCkkoFwu/loMLIfrmESkZZkJAY5NARXzQSuaRIVCP5NJTKJHByCEm6He0oIKPaZnQ6RJuy86YdrmERmUlUoHZ1wBQOQvqTZ2RDlT4spVRZMIhpTMgmZTPIh1GQLWowQrTrC5JQskQXIaAwynYGrvCz7gjA3HyL6oJxGmA0z6+F1G7vWEmpqGPXVKbHNjs/Y5rznk2qyu2Yb504xfFrKrGtnXGOklCQ27DQgkI2nZIWU8qSpxWIxBINBRKNRBALsh0lEVGj0/hwfOf/Mpcvh9hXndS4lOYzmB5dZrubkNMJcuXgNelp69cplTKGmBixbdyuWL1iN8J52x8Q2Oz5jm/ue37/kZwgfPApkFIijEUNjG33tjGuMlMJNZfnKqWC2N3egbVeHXrmcUHhPO/bvaHVcbLPjM7Y5Dr++F/s740CFH2jrhBgcMmyayqxrZ1x9ZWTakDjc9ENEhhNHjgJtR4CzZwIebminAmFyp5/vfve7EELgtttuO/WTfAgWTCILE4PDEFt2Q541A3JChdnpEFnali1b8NBDD+Gss87S5fwsmERWJgGkFeDgEaC8FLKh1uyMiE7MpBHmwMAAFixYgIcffhiVlZV5X8ZYWDCJCoDojQDpDFDshazwm50O0YcyqzXekiVLcM0112D+/PnaX9R7uDBCVCBEe3e2WJ4xBdj2LpBRzE6JSFexWGzUr30+H3y+D/YC+OUvf4nt27djy5YtuubDESZRARGROMTWdyHPnw0ZLDc7HaIP0nBKNhQKIRgMHjtWrFjxgXDhcBi33nor1q1bh+Li/O7/PBmOMIkKjaIA77YCNZWQ5aUQ7d1mZ0R0jJa3lYTD4VGNC8YaXW7btg3d3d2YN2/esdcURcGrr76KH/3oR0gmk3C73fkl9B4WTKICJKIDkOUlgMcDWVMJ0dNvdkpEWRq2xgsEAift9PPxj38cb7311qjXFi1ahKamJnzjG9/QrFgCLJhEBUu092RvNQnVAZE4kMlYtgcnkV78fj/mzp076rWysjJUV1d/4PV8cQ2TqICJoxGI3fshL5wDWaLv+g3RuJjcuEBPHGESFbpMBtixF5haD9kfy3YIIjKJQP5Pp8v3+zds2JDnGcbGESZRoZPZjkDoi2XXNCdNMDsjIltiwSSyCdF5FEingaogZImPD6Emc9h4SpYFk8hGRGcvcOAwMG8WUMQVFzKeWZ1+jMCCSWQzYjgJ8cZuyDnTIWv06alJ5EQsmER2I5HtO3u4GygthmyoMTsjchJOyRJRoRE9/dnCWVoCGSgzOx1yEhsWS4AFk8jWREcP0NULzD4N8GjX8YTIiVgwiWxOxBIQW9+BnDeLjwYj3XHTDxEVtowCNB8CqoN8CDXpi2uYRFToRCQODKeAIg9kddDsdMimOMIkIlsQ7d1APAFMrQeK3GxuQJQDFkwihxG9UYidzZAXzIUsLTE7HbIbG0/JshUIkRMpCrCzGQjVQUbjbNhOmtHyAdJWwxEmkRNJQCSGgGg8u6Y5sdrsjIgsjwWTyMHEkaNAMg3UVkL6isxOh+zAxlOyLJhEDie6eoF9bcCs0957xaKfVlQYbFwwc1rDbJhZD6/bp1cuYwo1NYz66pTYZsdnbIe95wIIZYYAAGfeWAcjt8+adc1Oi5tSktiw09CQtiOklCet5bFYDMFgENFoFIFAwIi8iIhIQ3p/jo+c/+yFy+H2Fud1LiU1jJ2PLbNczclphLly8Rr0tPTqlcuYQk0NWLbuVixfsBrhPe2OiW12fMZ27nv+0NrvY6A0jM4/eTCwXwCqvqNNs67ZaXFTStKYQFpMqdphSra9uQNtuzr0yuWEwnvasX9Hq+Nimx2fsc1hZvw3H+5Cj9KG8x4Zwu6PlSETAyD1n6I165qdEjcj04bFsitu+iGiD4juduHVK8pw8bODmPC3itnpUAERUmpyWBELJhF9kCqQiQPv3utD1UUKpnwhZXZGVChsvEuWBZOIxiYFjm7wINkt4KuRqLkiY90WLGQZbL5ORI516BEv+ja70fStJDwBAC6LfpoR6YwFk4hO6ugrbmz6VCk++lICwbmq2emQlXFKlogcTQpkBoBti0oQujGNyZ/nmiaNjVOyRESqQHSXG7G3XCgKSNR/Kg3LDgWIdMCCSUQ5aftPLwYPu9D4uTSKJ0kIN4smHYdTskREf3XkuSLs+loxLnshgeJ6i366kSk4JUtE9D7JboH/vqoMc74zjIZPs4sM2R8LJhGdEqkIDIVdOPK7IvhqVYRu5EYgAqdkiYg+TPszRUhHBSovUOCfpXBNk2w5HQuwYBKRBsLrvGhd68WFTw5lmxtYdYhAlAcWTCLSxECzC69eXoYLnxxE7SfYsN2xpNTmsCAWTCLShFQE0hFg30ofgmcqmLKIa5pOxF2yRETjItD9ogepPoGSBhXVl7Jhu+Nw0w8R0fgdesSLnpc9mPvdYXj8YMN2sgUWTCLSRe9GN/776jL8zQsJVM5jw3anEKo2hxWxYBKRPqRAJgHs+GoJJl2fxpR/5ZqmI3BKlojoFKgCkW1uDOxzwROQqLuWDdupcLFgEpHu2h7zItHiwtQvpuGtYcN2O+MuWSKiPHX+Pw+2f6kYH30pgdIpFv1EpPzxPkwionwJpPsFNl1Xhpl3JNF4A9c0qbCwYBKRYaQikDjgQs96D7xVEo3/xKJpN5ySJSLS0OGnipDqF6j5WwUljRa9h4BOjY13yXrMToCInOnwk170v6Hg+j8Nv/eKRT8lid6TU8FsmFkPr9unVy5jCjU1jPrqlNhmx2dsvudGEG6J7pX1wFrgyhsrAEwzLLZZP2uz4qaUJDbs1D+OFlOqVp2SFVKefDtSLBZDMBhENBpFIBAwIi8iItKQ3p/jI+f/yNX3wlNUnNe5MulhvP7HuyxXc3IaYa5cvAY9Lb165TKmUFMDlq27FcsXrEZ4T7tjYpsdn7H5nhsdd/0j96LYux+b1wew/60SSFUYEtes6zU6bkpJGhLHziPMnApme3MH2nZ16JXLCYX3tGP/jlbHxTY7PmObw4nX/usfDaC0pAf3PPIGPn/hLCTibt2LJmDe9RodNyPThsWyK+6SJSLLeOv1Mnz+wll4ZOMenHvZgNnp0Kmw8S5ZFkwisgypCiTibqz4yhRcdk0En/lKt9kpUY54HyYRkUGkKrD9VT+OHPQhUJ3B31wbgWWHHOQoLJhEZEm/WlOL5jdLseibRxCsVuBiw/bCoEptDgtiwSQiy/rLH4L42j/MwJM73sbUpuGTfwOZj2uYRERmEIhH3Lj5qpn4/Nc7cd0Xe8xOiByMBZOILE1VBA68XYIdfylHoELB1Tcaey845UZAg00/Zl/Eh2DBJKKC8Nuf1aC3qwiXX9+PhmlJuLmmaU18HiYRkfn++Hg1Vn89hJ+/9i4qa9Ow7GIX2RILJhEVlM42LxacPxvffrQVf/fZfrPToffhfZhERBahKAJHjxThuZ/VoH5qEv94E5sbWAp3yRIRWYnAC09XIR5xY8ZZQ5h9fgIul0U/ZR1GSKnJkYsVK1bgggsugN/vR21tLa6//nrs3btX82tjwSSigvWbn9Ti949OwHefakGpX4Gw6lwe6eqVV17BkiVL8Prrr+OFF15AOp3GJz7xCSQSCU3j5PS0EiIiq9mzvRT/PG82Ht6wF6u+3ojNLwbNTsnZ1PeOfM+Rg+eff37Urx999FHU1tZi27Zt+OhHP5pnMn/FgklEBU1VBRIxN1Z9vRHz/nYAoRlJ/HpNrdlpOdapTKmOdQ4g+1Dq4/l8Pvh8vpN+fzQaBQBUVVXllcf7cUqWiAqelAKbXwyip6MI1RPTuPjKqHW3WtK4hUIhBIPBY8eKFStO+j2qquK2227DpZdeirlz52qaD0eYRGQbv15Ti4uvjGLJ/Yexe/MZSMTdUBWr9o2xKS12ub73/eFwGIFA4NjL4xldLlmyBLt378Zrr72WZxIfxBEmEdnKpj8H8JX5Z+DJHW9jxlmDZqfjPBp2+gkEAqOOkxXMm2++GX/4wx/w8ssvo7GxUfNLY8EkInuR2YdQ/89/PB3/46YefOpLbNhud1JK3HzzzXj22Wfx0ksvYdq0abrEYcEkIttRFYG9O8rw7vYy+IMKrryBDduNYkannyVLluDxxx/HE088Ab/fj87OTnR2dmJoaEjTa2PBJCLbevbhGnQdLsLV/9KL2sYUG7YbwYTm62vWrEE0GsXll1+OSZMmHTueeuopTS+Nm36IyNb+65fV2PGaH//5xjtY+JFZ6Gw7+cYRKizSoKebcIRJRLbXe6QICz8yC7f/oA1//8+cntWTULU5rIgFk4hsT1EEOtt8+PPTVaipT+NTi7kRSDd8HiYRUeF7/olqDETcmHvRACbPGDY7HXuy8dNKuIZJRI7y7E9rsPuNMqx+vs3sVKjA5FQwG2bWw+s2dsE81NQw6qtTYpsdn7H5nts5rnBL/PCueiz9CTD5uimGxQXM+zmnlCQ27NQ/jpa9ZK1GyHFsL4rFYggGg4hGo6PaFBERUWHQ+3N85PxXnPdNeDzFeZ0rkxnGy9tWWK7m5DTCXLl4DXpajN1hFmpqwLJ1t2L5gtUI72l3TGyz4zM233OnxF3xo4dwONkFuSsF+XZK9/Uzs643pSQNi2VXORXM9uYOtO3q0CuXEwrvacf+Ha2Oi212fMY2hxOv3ay4bY+0oKWoA647KqE81wUkZP7PcxwHo683I9PGBJLI/+dnzRlZ7pIlIpJbklAWdsH9VB0wx2t2OgVtZA0z38OKWDCJiCSAhITyjV64ri2F+GyZ2RmRBbFgEhEB2WnEt1KQLWkIvwvi70rMzqgwSWjQuMDsixgbCyYR0XHk0wnItgxcnysHJrgAt9kZFRh2+iEicg75whCUO3rhfroOqGd/F8piwSQiGku/CmVhN1y3BSGuKzU7m8KhanRYEAsmEdFYFADhDOSrQ0CFG+J6bgQaD+6SJSJyKPnbQSCqQlzkA07zcE3zZLiGSUTkXPK5BNSHY3A/XAsE+LHpVHzniYjG41AGyqc74V49AeJjvOXkQ3GESUTkcAqAfhXqo3GI6R6Iz3FNc0wsmEREBADypSHImAoR8kDM8wLC7IzIKCyYREQ5kk8lIF8aguvbVUCZYNE8Hm8rISKi48kdKSj/1AX3kxOzI00CwNtKiIjo/d5r2K7e0wdxeQnXNB2ABZOI6FRJQG5LQR7OQATdEFdw9yw3/RAR0YeSTyUg96Xh+oIfqHB4w3ZVanNYEAsmEZEG5MtDUP79KNzP1AFT2bDdjlgwiYi0Eleh3NQN1xcDEJ9y6Jomp2SJiOikFAAtGcgtSSDogvgHJz7lRItiyYJJROQI8tkE0KdAXF4ChNzOWtPkCJOIiHIhfzcI9T8icP9iIlDJj1o74LtIRKSXDgXKZzrhXlEN8QmH3HJi412y3MpFRKQXBcBRFeqvBoCQB+KzZcA+s5PSmVSzR77nsCCOMImIdCb/PATEVYjTi4DTi8xOh04RR5hERAaQTycg53rhXhs0OxV9abFpx6KbfnIqmA0z6+F1+/TKZUyhpoZRX50S2+z4jM33nHF14ALqHy4GLgFC5043Li6AlJLEhp0GBFI1uC3EomuYQsqTl/JYLIZgMIhoNIpAIGBEXkREpCG9P8dHzj+/4d/gceU3sMqoSbzYvtZyNSenEebKxWvQ09KrVy5jCjU1YNm6W7F8wWqE97Q7JrbZ8Rmb7znj6hz3qz/D4dYeyMFhYGBQ97gpJal7DACckh3R3tyBtl0deuVyQuE97di/o9Vxsc2Oz9jmcOK1Oy7u5r3Yf+AoRGMd5J42QFF0jZeRaV3Pf4yEBgVTk0w0x12yRERmicYh9xyAOPMMoLTY7GzoJLhLlojITIoC2XwAYmINZGIQ6DZ22UtznJIlIiLdDA5DJgYh3C7I6gqgN2J2RqdOVQHk2XhAZeMCIiL6MN29kKk0RHUl4C0ChNkJnSI2XyciIt31RiAPHoaYMxMoYkcgq2HBJCKyknQa8u1miGmNQHWF2dnkzsYjTK5hEhFZiQSQSkMe7YfwFkHWVAE9fWZnNX427vTDESYRkRX1RiAzCkR5KVDqkEeDWRwLJhGRVfX0QXb1QsycBrjdZmczLlKqmhxWxIJJRGRlg0OQb+2FmDUdCPrNzubkpAYPj7boGiYLJhGR1SkKZPhIdnp2YrXZ2TgWCyYRUSGIxiEzGYiiIiBQbnY2H87Gu2RZMImICkVXL2RsAGJKA+C26Me3qmpzWJBFf+JERDSm2ADkO/uyDdvLSs3OxlF4HyYRUaFRVMh9hyAmVEKWlVirYbvU4D5Mi07JsmASERWixCBkWQmE2w1ZVQH0RczOCAAgVRVS5DelyttKiIhIW929kMkURG01UOSxRsN2bvohIiJL6otAthyCmHsG4PWanY2tcUqWiKjQZTLZjUCT6yH7o8DRfvNyUSUguIZJRERWJAEkU9liWeQBzGzYLiXyfoC0RQsmp2SJiOziaD+QUSAC5UCJz+xsbIcjTCIiO+npgxxIQDRNh3xrL5BRDA0vVQmZ55Ss5AiTiIgMMZTMNmyfOQ2oCBgbW6raHDn68Y9/jKlTp6K4uBgXXXQR3njjDc0vjQWTiMiOMgpkRzdEaYntG7Y/9dRTWLp0Ke6++25s374dZ599Nq688kp0d3drGocFk4jIriIxSCUD4fMCfmPa6ElVanLk4sEHH8SXvvQlLFq0CLNnz8batWtRWlqKn//855peGwsmEZGddfVC9scgTptiTDyDp2RTqRS2bduG+fPnH3vN5XJh/vz52LRpk6aXJuQ4Vlej0SgqKioQDocRCBg8H05ERHmLxWIIhUKIRCIIBoO6nD8YDOIyXA0PivI6VwZpvIY/fqDm+Hw++Hyjd/92dHSgoaEBGzduxMUXX3zs9dtvvx2vvPIKNm/enFcuxxvXLtl4PA4ACIVCmgUmIiLjxeNxXQqm1+tFXV0dXuv8oybnKy8v/0DNufvuu3HPPfdocv5TMa6CWV9fj3A4DL/fDyGs0KyQiIhyIaVEPB5HfX29LucvLi5Ga2srUqmUJueTUn6g3rx/dAkAEyZMgNvtRldX16jXu7q6UFdXp0kuI8ZVMF0uFxobGzUNTERExtJjZHm84uJiFBcX6xrj/bxeL8477zysX78e119/PQBAVVWsX78eN998s6ax2LiAiIgK2tKlS7Fw4UKcf/75uPDCC7Fq1SokEgksWrRI0zgsmEREVNA+97nPoaenB3fddRc6Oztxzjnn4Pnnn8fEiRM1jTOuXbJEREROx/swiYiIxoEFk4iIaBxYMImIiMaBBZOIiGgcWDCJiIjGgQWTiIhoHFgwiYiIxoEFk4iIaBxYMImIiMaBBZOIiGgcWDCJiIjGgQWTiIhoHP4/apGtpBTUJ3MAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "### Creating the block-diagonal inverse noise covariance operator\n",
+    "\n",
+    "# As we have already prepared the list individual block operators, we just need to\n",
+    "# pass it to the base class of block-diagonal inverse noise covariance\n",
+    "# operator\n",
+    "\n",
+    "inv_blkdiag = brahmap.base.BaseBlockDiagInvNoiseCovLinearOperator(\n",
+    "    block_list=list_ops,\n",
+    ")\n",
+    "\n",
+    "### Visualizing the operator\n",
+    "plot_LinearOperator(inv_blkdiag)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b31ead5",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/lbsim_noise_covariances.ipynb
+++ b/examples/lbsim_noise_covariances.ipynb
@@ -31,6 +31,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "f2e145d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib healpy litebird_sim git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "58ecb489",
    "metadata": {},

--- a/examples/rectangular_I_map_explicit.ipynb
+++ b/examples/rectangular_I_map_explicit.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### If you are using Google Colab, uncomment the following line and execute this cell to install the required packages\n",
+    "\n",
+    "# %pip install matplotlib git+https://github.com/anand-avinash/BrahMap.git"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
This PR adds the Google Colab links for notebook examples and adds information to install required packages when using Colab. We have also added an example of using base inverse block-diagonal covariance operator for `litebird_sim`.