### PR TITLE
Updating the call to `scipy.sparse.linalg._isolve.utils.make_system`

### DIFF
--- a/tests/test_noise_ops_toeplitz.py
+++ b/tests/test_noise_ops_toeplitz.py
@@ -142,8 +142,8 @@ class NoiseOps_Toeplitz(BaseTestNoiseLO):
 
 class TestNoiseOps_Toeplitz_F32(NoiseOps_Toeplitz):
     dtype = np.float32
-    rtol = 1.0e-4
-    atol = 1.0e-5
+    rtol = 1.0e-3
+    atol = 1.0e-4
 
 
 class TestNoiseOps_Toeplitz_F64(NoiseOps_Toeplitz):


### PR DESCRIPTION
We have used the SciPy function `scipy.sparse.linalg._isolve.utils.make_system()` in `brahmap.math.linalg.cg()` keeping it consistent with `scipy.sparse.linalg.cg()`. With SciPy 1.16.0, the function `scipy.sparse.linalg._isolve.utils.make_system()` returns only 4 object instead of 5. This PR updated `cg()` according to this change.