### PR TITLE
Refactoring the C++ extensions: migrating from pybind11 to nanobind

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,8 @@ on: [push]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.15"  # To be removed when support for Python 3.11 is dropped
     strategy:
       fail-fast: false
       matrix:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "extern/pybind11"]
-	path = extern/pybind11
-	url = https://github.com/pybind/pybind11.git
-	branch = stable

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-recursive-include extern *
 recursive-include tests *
 global-exclude */__pycache__/*
 global-exclude *.pyc

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ compiler. To install `BrahMap`, please follow these steps:
 
 ```shell
 # Clone the repository
-git clone --recursive https://github.com/anand-avinash/BrahMap.git
+git clone https://github.com/anand-avinash/BrahMap.git
 
 # Enter the directory
 cd BrahMap

--- a/brahmap/_extensions/BlkDiagPrecondLO_tools.cpp
+++ b/brahmap/_extensions/BlkDiagPrecondLO_tools.cpp
@@ -1,14 +1,13 @@
-#include <functional>
 #include <vector>
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #ifndef _DISABLE_OMP
 #include <omp.h>
 #endif
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 template <typename dfloat>
 void BDPLO_mult_QU(                                //
@@ -86,171 +85,83 @@ void BDPLO_mult_IQU(                               //
   return;
 } // BDPLO_mult_IQU()
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dfloat>
-std::function<void(                              //
-    const ssize_t new_npix,                      //
-    const buffer_t<dfloat> weighted_sin_sq,      //
-    const buffer_t<dfloat> weighted_cos_sq,      //
-    const buffer_t<dfloat> weighted_sincos,      //
-    const buffer_t<dfloat> one_over_determinant, //
-    const buffer_t<dfloat> vec,                  //
-    buffer_t<dfloat> prod                        //
-    )>
-    numpy_bind_BDPLO_mult_QU =                //
-    [](const ssize_t new_npix,                //
-       const py::buffer weighted_sin_sq,      //
-       const py::buffer weighted_cos_sq,      //
-       const py::buffer weighted_sincos,      //
-       const py::buffer one_over_determinant, //
-       const py::buffer vec,                  //
-       py::buffer prod                        //
-    ) {
-      py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
-      py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
-      py::buffer_info weighted_sincos_info = weighted_sincos.request();
-      py::buffer_info one_over_determinant_info =
-          one_over_determinant.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
+template <typename dfloat, typename device> //
+void register_BlkDiagPrecondLO(nb::module_ &m) {
+  using arr_t = nb::ndarray<dfloat, nb::ndim<1>, device, nb::c_contig>;
 
-      const dfloat *weighted_sin_sq_ptr =
-          reinterpret_cast<const dfloat *>(weighted_sin_sq_info.ptr);
-      const dfloat *weighted_cos_sq_ptr =
-          reinterpret_cast<const dfloat *>(weighted_cos_sq_info.ptr);
-      const dfloat *weighted_sincos_ptr =
-          reinterpret_cast<const dfloat *>(weighted_sincos_info.ptr);
-      const dfloat *one_over_determinant_ptr =
-          reinterpret_cast<const dfloat *>(one_over_determinant_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
+  m.def(
+      "BDPLO_mult_QU",                      //
+      [](                                   //
+          const ssize_t new_npix,           //
+          const arr_t weighted_sin_sq,      //
+          const arr_t weighted_cos_sq,      //
+          const arr_t weighted_sincos,      //
+          const arr_t one_over_determinant, //
+          const arr_t vec,                  //
+          arr_t prod                        //
+      ) {
+        BDPLO_mult_QU(                   //
+            new_npix,                    //
+            weighted_sin_sq.data(),      //
+            weighted_cos_sq.data(),      //
+            weighted_sincos.data(),      //
+            one_over_determinant.data(), //
+            vec.data(),                  //
+            prod.data()                  //
+        );
+      },
+      nb::arg("new_npix"),                         //
+      nb::arg("weighted_sin_sq").noconvert(),      //
+      nb::arg("weighted_cos_sq").noconvert(),      //
+      nb::arg("weighted_sincos").noconvert(),      //
+      nb::arg("one_over_determinant").noconvert(), //
+      nb::arg("vec").noconvert(),                  //
+      nb::arg("prod").noconvert()                  //
+  );
 
-      BDPLO_mult_QU(                //
-          new_npix,                 //
-          weighted_sin_sq_ptr,      //
-          weighted_cos_sq_ptr,      //
-          weighted_sincos_ptr,      //
-          one_over_determinant_ptr, //
-          vec_ptr,                  //
-          prod_ptr                  //
-      );
+  m.def(
+      "BDPLO_mult_IQU",                     //
+      [](                                   //
+          const ssize_t new_npix,           //
+          const arr_t weighted_counts,      //
+          const arr_t weighted_sin_sq,      //
+          const arr_t weighted_cos_sq,      //
+          const arr_t weighted_sincos,      //
+          const arr_t weighted_sin,         //
+          const arr_t weighted_cos,         //
+          const arr_t one_over_determinant, //
+          const arr_t vec,                  //
+          arr_t prod                        //
+      ) {
+        BDPLO_mult_IQU(                  //
+            new_npix,                    //
+            weighted_counts.data(),      //
+            weighted_sin_sq.data(),      //
+            weighted_cos_sq.data(),      //
+            weighted_sincos.data(),      //
+            weighted_sin.data(),         //
+            weighted_cos.data(),         //
+            one_over_determinant.data(), //
+            vec.data(),                  //
+            prod.data()                  //
+        );
+      },
+      nb::arg("new_npix"),                         //
+      nb::arg("weighted_counts").noconvert(),      //
+      nb::arg("weighted_sin_sq").noconvert(),      //
+      nb::arg("weighted_cos_sq").noconvert(),      //
+      nb::arg("weighted_sincos").noconvert(),      //
+      nb::arg("weighted_sin").noconvert(),         //
+      nb::arg("weighted_cos").noconvert(),         //
+      nb::arg("one_over_determinant").noconvert(), //
+      nb::arg("vec").noconvert(),                  //
+      nb::arg("prod").noconvert()                  //
+  );
+}
 
-      return;
-    }; // numpy_bind_BDPLO_mult_QU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dfloat>
-std::function<void(                              //
-    const ssize_t new_npix,                      //
-    const buffer_t<dfloat> weighted_counts,      //
-    const buffer_t<dfloat> weighted_sin_sq,      //
-    const buffer_t<dfloat> weighted_cos_sq,      //
-    const buffer_t<dfloat> weighted_sincos,      //
-    const buffer_t<dfloat> weighted_sin,         //
-    const buffer_t<dfloat> weighted_cos,         //
-    const buffer_t<dfloat> one_over_determinant, //
-    const buffer_t<dfloat> vec,                  //
-    buffer_t<dfloat> prod                        //
-    )>
-    numpy_bind_BDPLO_mult_IQU =               //
-    [](const ssize_t new_npix,                //
-       const py::buffer weighted_counts,      //
-       const py::buffer weighted_sin_sq,      //
-       const py::buffer weighted_cos_sq,      //
-       const py::buffer weighted_sincos,      //
-       const py::buffer weighted_sin,         //
-       const py::buffer weighted_cos,         //
-       const py::buffer one_over_determinant, //
-       const py::buffer vec,                  //
-       py::buffer prod                        //
-    ) {
-      py::buffer_info weighted_counts_info = weighted_counts.request();
-      py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
-      py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
-      py::buffer_info weighted_sincos_info = weighted_sincos.request();
-      py::buffer_info weighted_sin_info = weighted_sin.request();
-      py::buffer_info weighted_cos_info = weighted_cos.request();
-      py::buffer_info one_over_determinant_info =
-          one_over_determinant.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
-
-      const dfloat *weighted_counts_ptr =
-          reinterpret_cast<const dfloat *>(weighted_counts_info.ptr);
-      const dfloat *weighted_sin_sq_ptr =
-          reinterpret_cast<const dfloat *>(weighted_sin_sq_info.ptr);
-      const dfloat *weighted_cos_sq_ptr =
-          reinterpret_cast<const dfloat *>(weighted_cos_sq_info.ptr);
-      const dfloat *weighted_sincos_ptr =
-          reinterpret_cast<const dfloat *>(weighted_sincos_info.ptr);
-      const dfloat *weighted_sin_ptr =
-          reinterpret_cast<const dfloat *>(weighted_sin_info.ptr);
-      const dfloat *weighted_cos_ptr =
-          reinterpret_cast<const dfloat *>(weighted_cos_info.ptr);
-      const dfloat *one_over_determinant_ptr =
-          reinterpret_cast<const dfloat *>(one_over_determinant_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
-
-      BDPLO_mult_IQU(               //
-          new_npix,                 //
-          weighted_counts_ptr,      //
-          weighted_sin_sq_ptr,      //
-          weighted_cos_sq_ptr,      //
-          weighted_sincos_ptr,      //
-          weighted_sin_ptr,         //
-          weighted_cos_ptr,         //
-          one_over_determinant_ptr, //
-          vec_ptr,                  //
-          prod_ptr                  //
-      );
-
-      return;
-    }; // numpy_bind_BDPLO_mult_IQU()
-
-PYBIND11_MODULE(BlkDiagPrecondLO_tools, m) {
+NB_MODULE(BlkDiagPrecondLO_tools, m) {
   m.doc() = "BlkDiagPrecondLO_tools";
-  m.def("BDPLO_mult_QU", numpy_bind_BDPLO_mult_QU<py::array_t, float>, //
-        py::arg("new_npix"),                                           //
-        py::arg("weighted_sin_sq").noconvert(),                        //
-        py::arg("weighted_cos_sq").noconvert(),                        //
-        py::arg("weighted_sincos").noconvert(),                        //
-        py::arg("one_over_determinant").noconvert(),                   //
-        py::arg("vec").noconvert(),                                    //
-        py::arg("prod").noconvert()                                    //
-  );
-  m.def("BDPLO_mult_QU", numpy_bind_BDPLO_mult_QU<py::array_t, double>, //
-        py::arg("new_npix"),                                            //
-        py::arg("weighted_sin_sq").noconvert(),                         //
-        py::arg("weighted_cos_sq").noconvert(),                         //
-        py::arg("weighted_sincos").noconvert(),                         //
-        py::arg("one_over_determinant").noconvert(),                    //
-        py::arg("vec").noconvert(),                                     //
-        py::arg("prod").noconvert()                                     //
-  );
 
-  m.def("BDPLO_mult_IQU", numpy_bind_BDPLO_mult_IQU<py::array_t, float>, //
-        py::arg("new_npix"),                                             //
-        py::arg("weighted_counts").noconvert(),                          //
-        py::arg("weighted_sin_sq").noconvert(),                          //
-        py::arg("weighted_cos_sq").noconvert(),                          //
-        py::arg("weighted_sincos").noconvert(),                          //
-        py::arg("weighted_sin").noconvert(),                             //
-        py::arg("weighted_cos").noconvert(),                             //
-        py::arg("one_over_determinant").noconvert(),                     //
-        py::arg("vec").noconvert(),                                      //
-        py::arg("prod").noconvert()                                      //
-  );
-  m.def("BDPLO_mult_IQU", numpy_bind_BDPLO_mult_IQU<py::array_t, double>, //
-        py::arg("new_npix"),                                              //
-        py::arg("weighted_counts").noconvert(),                           //
-        py::arg("weighted_sin_sq").noconvert(),                           //
-        py::arg("weighted_cos_sq").noconvert(),                           //
-        py::arg("weighted_sincos").noconvert(),                           //
-        py::arg("weighted_sin").noconvert(),                              //
-        py::arg("weighted_cos").noconvert(),                              //
-        py::arg("one_over_determinant").noconvert(),                      //
-        py::arg("vec").noconvert(),                                       //
-        py::arg("prod").noconvert()                                       //
-  );
+  register_BlkDiagPrecondLO<double, nb::device::cpu>(m);
+  register_BlkDiagPrecondLO<float, nb::device::cpu>(m);
 }

--- a/brahmap/_extensions/PointingLO_tools.cpp
+++ b/brahmap/_extensions/PointingLO_tools.cpp
@@ -1,7 +1,5 @@
-#include <functional>
-
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #ifndef _DISABLE_OMP
 #include <omp.h>
@@ -9,7 +7,7 @@
 
 #include "mpi_utils.hpp"
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 template <typename dint, typename dfloat>
 void PLO_mult_I(                           //
@@ -184,543 +182,209 @@ void PLO_rmult_IQU(                        //
   return;
 } // PLO_rmult_IQU()
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                      //
-    const ssize_t nsamples,              //
-    const buffer_t<dint> pointings,      //
-    const buffer_t<bool> pointings_flag, //
-    const buffer_t<dfloat> vec,          //
-    buffer_t<dfloat> prod                //
-    )>
-    numpy_bind_PLO_mult_I =             //
-    [](const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer vec,            //
-       py::buffer prod                  //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
+template <typename dint, typename dfloat, typename device> //
+void register_PointingLO(nb::module_ &m) {
+  using arr_dint = nb::ndarray<dint, nb::ndim<1>, device, nb::c_contig>;
+  using arr_dfloat = nb::ndarray<dfloat, nb::ndim<1>, device, nb::c_contig>;
+  using arr_bool = nb::ndarray<bool, nb::ndim<1>, device, nb::c_contig>;
 
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
+  auto get_comm = [](const nb::object &mpi4py_comm) -> MPI_Comm {
+    return (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
+        ->ob_mpi;
+  };
 
-      PLO_mult_I(             //
-          nsamples,           //
-          pointings_ptr,      //
-          pointings_flag_ptr, //
-          vec_ptr,            //
-          prod_ptr            //
-      );
+  m.def(
+      "PLO_mult_I",                      //
+      [](                                //
+          const ssize_t nsamples,        //
+          const arr_dint pointings,      //
+          const arr_bool pointings_flag, //
+          const arr_dfloat vec,          //
+          arr_dfloat prod                //
+      ) {
+        PLO_mult_I(                //
+            nsamples,              //
+            pointings.data(),      //
+            pointings_flag.data(), //
+            vec.data(),            //
+            prod.data()            //
+        );
+      },
+      nb::arg("nsamples"),                   //
+      nb::arg("pointings").noconvert(),      //
+      nb::arg("pointings_flag").noconvert(), //
+      nb::arg("vec").noconvert(),            //
+      nb::arg("prod").noconvert()            //
+  );
 
-      return;
-    }; // numpy_bind_PLO_mult_I()
+  m.def(
+      "PLO_rmult_I",                     //
+      [get_comm](                        //
+          const ssize_t new_npix,        //
+          const ssize_t nsamples,        //
+          const arr_dint pointings,      //
+          const arr_bool pointings_flag, //
+          const arr_dfloat vec,          //
+          arr_dfloat prod,               //
+          const nb::object mpi4py_comm   //
+      ) {
+        PLO_rmult_I(               //
+            new_npix,              //
+            nsamples,              //
+            pointings.data(),      //
+            pointings_flag.data(), //
+            vec.data(),            //
+            prod.data(),           //
+            get_comm(mpi4py_comm)  //
+        );
+      },
+      nb::arg("new_npix"),                   //
+      nb::arg("nsamples"),                   //
+      nb::arg("pointings").noconvert(),      //
+      nb::arg("pointings_flag").noconvert(), //
+      nb::arg("vec").noconvert(),            //
+      nb::arg("prod").noconvert(),           //
+      nb::arg("comm").noconvert()            //
+  );
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                      //
-    const ssize_t new_npix,              //
-    const ssize_t nsamples,              //
-    const buffer_t<dint> pointings,      //
-    const buffer_t<bool> pointings_flag, //
-    const buffer_t<dfloat> vec,          //
-    buffer_t<dfloat> prod,               //
-    const py::object mpi4py_comm         //
-    )>
-    numpy_bind_PLO_rmult_I =            //
-    [](const ssize_t new_npix,          //
-       const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer vec,            //
-       py::buffer prod,                 //
-       const py::object mpi4py_comm     //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
+  m.def(
+      "PLO_mult_QU",                     //
+      [](                                //
+          const ssize_t nsamples,        //
+          const arr_dint pointings,      //
+          const arr_bool pointings_flag, //
+          const arr_dfloat sin2phi,      //
+          const arr_dfloat cos2phi,      //
+          const arr_dfloat vec,          //
+          arr_dfloat prod                //
+      ) {
+        PLO_mult_QU(               //
+            nsamples,              //
+            pointings.data(),      //
+            pointings_flag.data(), //
+            sin2phi.data(),        //
+            cos2phi.data(),        //
+            vec.data(),            //
+            prod.data()            //
+        );
+      },
+      nb::arg("nsamples"),                   //
+      nb::arg("pointings").noconvert(),      //
+      nb::arg("pointings_flag").noconvert(), //
+      nb::arg("sin2phi").noconvert(),        //
+      nb::arg("cos2phi").noconvert(),        //
+      nb::arg("vec").noconvert(),            //
+      nb::arg("prod").noconvert()            //
+  );
 
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
+  m.def(
+      "PLO_rmult_QU",                    //
+      [get_comm](                        //
+          const ssize_t new_npix,        //
+          const ssize_t nsamples,        //
+          const arr_dint pointings,      //
+          const arr_bool pointings_flag, //
+          const arr_dfloat sin2phi,      //
+          const arr_dfloat cos2phi,      //
+          const arr_dfloat vec,          //
+          arr_dfloat prod,               //
+          const nb::object mpi4py_comm   //
+      ) {
+        PLO_rmult_QU(              //
+            new_npix,              //
+            nsamples,              //
+            pointings.data(),      //
+            pointings_flag.data(), //
+            sin2phi.data(),        //
+            cos2phi.data(),        //
+            vec.data(),            //
+            prod.data(),           //
+            get_comm(mpi4py_comm)  //
+        );
+      },
+      nb::arg("new_npix"),                   //
+      nb::arg("nsamples"),                   //
+      nb::arg("pointings").noconvert(),      //
+      nb::arg("pointings_flag").noconvert(), //
+      nb::arg("sin2phi").noconvert(),        //
+      nb::arg("cos2phi").noconvert(),        //
+      nb::arg("vec").noconvert(),            //
+      nb::arg("prod").noconvert(),           //
+      nb::arg("comm").noconvert()            //
+  );
 
-      const MPI_Comm comm =
-          (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
-              ->ob_mpi;
+  m.def(
+      "PLO_mult_IQU",                    //
+      [](                                //
+          const ssize_t nsamples,        //
+          const arr_dint pointings,      //
+          const arr_bool pointings_flag, //
+          const arr_dfloat sin2phi,      //
+          const arr_dfloat cos2phi,      //
+          const arr_dfloat vec,          //
+          arr_dfloat prod                //
+      ) {
+        PLO_mult_IQU(              //
+            nsamples,              //
+            pointings.data(),      //
+            pointings_flag.data(), //
+            sin2phi.data(),        //
+            cos2phi.data(),        //
+            vec.data(),            //
+            prod.data()            //
+        );
+      },
+      nb::arg("nsamples"),                   //
+      nb::arg("pointings").noconvert(),      //
+      nb::arg("pointings_flag").noconvert(), //
+      nb::arg("sin2phi").noconvert(),        //
+      nb::arg("cos2phi").noconvert(),        //
+      nb::arg("vec").noconvert(),            //
+      nb::arg("prod").noconvert()            //
+  );
 
-      PLO_rmult_I(            //
-          new_npix,           //
-          nsamples,           //
-          pointings_ptr,      //
-          pointings_flag_ptr, //
-          vec_ptr,            //
-          prod_ptr,           //
-          comm                //
-      );
+  m.def(
+      "PLO_rmult_IQU",                   //
+      [get_comm](                        //
+          const ssize_t new_npix,        //
+          const ssize_t nsamples,        //
+          const arr_dint pointings,      //
+          const arr_bool pointings_flag, //
+          const arr_dfloat sin2phi,      //
+          const arr_dfloat cos2phi,      //
+          const arr_dfloat vec,          //
+          arr_dfloat prod,               //
+          const nb::object mpi4py_comm   //
+      ) {
+        PLO_rmult_IQU(             //
+            new_npix,              //
+            nsamples,              //
+            pointings.data(),      //
+            pointings_flag.data(), //
+            sin2phi.data(),        //
+            cos2phi.data(),        //
+            vec.data(),            //
+            prod.data(),           //
+            get_comm(mpi4py_comm)  //
+        );
+      },
+      nb::arg("new_npix"),                   //
+      nb::arg("nsamples"),                   //
+      nb::arg("pointings").noconvert(),      //
+      nb::arg("pointings_flag").noconvert(), //
+      nb::arg("sin2phi").noconvert(),        //
+      nb::arg("cos2phi").noconvert(),        //
+      nb::arg("vec").noconvert(),            //
+      nb::arg("prod").noconvert(),           //
+      nb::arg("comm").noconvert()            //
+  );
+}
 
-      return;
-    }; // numpy_bind_PLO_rmult_I()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                      //
-    const ssize_t nsamples,              //
-    const buffer_t<dint> pointings,      //
-    const buffer_t<bool> pointings_flag, //
-    const buffer_t<dfloat> sin2phi,      //
-    const buffer_t<dfloat> cos2phi,      //
-    const buffer_t<dfloat> vec,          //
-    buffer_t<dfloat> prod                //
-    )>
-    numpy_bind_PLO_mult_QU =            //
-    [](const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer sin2phi,        //
-       const py::buffer cos2phi,        //
-       const py::buffer vec,            //
-       py::buffer prod                  //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info sin2phi_info = sin2phi.request();
-      py::buffer_info cos2phi_info = cos2phi.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
-
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *sin2phi_ptr =
-          reinterpret_cast<const dfloat *>(sin2phi_info.ptr);
-      const dfloat *cos2phi_ptr =
-          reinterpret_cast<const dfloat *>(cos2phi_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
-
-      PLO_mult_QU(            //
-          nsamples,           //
-          pointings_ptr,      //
-          pointings_flag_ptr, //
-          sin2phi_ptr,        //
-          cos2phi_ptr,        //
-          vec_ptr,            //
-          prod_ptr            //
-      );
-
-      return;
-    }; // numpy_bind_PLO_mult_QU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                      //
-    const ssize_t new_npix,              //
-    const ssize_t nsamples,              //
-    const buffer_t<dint> pointings,      //
-    const buffer_t<bool> pointings_flag, //
-    const buffer_t<dfloat> sin2phi,      //
-    const buffer_t<dfloat> cos2phi,      //
-    const buffer_t<dfloat> vec,          //
-    buffer_t<dfloat> prod,               //
-    const py::object mpi4py_comm         //
-    )>
-    numpy_bind_PLO_rmult_QU =           //
-    [](const ssize_t new_npix,          //
-       const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer sin2phi,        //
-       const py::buffer cos2phi,        //
-       const py::buffer vec,            //
-       py::buffer prod,                 //
-       const py::object mpi4py_comm     //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info sin2phi_info = sin2phi.request();
-      py::buffer_info cos2phi_info = cos2phi.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
-
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *sin2phi_ptr =
-          reinterpret_cast<const dfloat *>(sin2phi_info.ptr);
-      const dfloat *cos2phi_ptr =
-          reinterpret_cast<const dfloat *>(cos2phi_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
-
-      const MPI_Comm comm =
-          (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
-              ->ob_mpi;
-
-      PLO_rmult_QU(           //
-          new_npix,           //
-          nsamples,           //
-          pointings_ptr,      //
-          pointings_flag_ptr, //
-          sin2phi_ptr,        //
-          cos2phi_ptr,        //
-          vec_ptr,            //
-          prod_ptr,           //
-          comm                //
-      );
-
-      return;
-    }; // numpy_bind_PLO_rmult_QU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                      //
-    const ssize_t nsamples,              //
-    const buffer_t<dint> pointings,      //
-    const buffer_t<bool> pointings_flag, //
-    const buffer_t<dfloat> sin2phi,      //
-    const buffer_t<dfloat> cos2phi,      //
-    const buffer_t<dfloat> vec,          //
-    buffer_t<dfloat> prod                //
-    )>
-    numpy_bind_PLO_mult_IQU =           //
-    [](const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer sin2phi,        //
-       const py::buffer cos2phi,        //
-       const py::buffer vec,            //
-       py::buffer prod                  //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info sin2phi_info = sin2phi.request();
-      py::buffer_info cos2phi_info = cos2phi.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
-
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *sin2phi_ptr =
-          reinterpret_cast<const dfloat *>(sin2phi_info.ptr);
-      const dfloat *cos2phi_ptr =
-          reinterpret_cast<const dfloat *>(cos2phi_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
-
-      PLO_mult_IQU(           //
-          nsamples,           //
-          pointings_ptr,      //
-          pointings_flag_ptr, //
-          sin2phi_ptr,        //
-          cos2phi_ptr,        //
-          vec_ptr,            //
-          prod_ptr            //
-      );
-
-      return;
-    }; // numpy_bind_PLO_mult_IQU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                      //
-    const ssize_t new_npix,              //
-    const ssize_t nsamples,              //
-    const buffer_t<dint> pointings,      //
-    const buffer_t<bool> pointings_flag, //
-    const buffer_t<dfloat> sin2phi,      //
-    const buffer_t<dfloat> cos2phi,      //
-    const buffer_t<dfloat> vec,          //
-    buffer_t<dfloat> prod,               //
-    const py::object mpi4py_comm         //
-    )>
-    numpy_bind_PLO_rmult_IQU =          //
-    [](const ssize_t new_npix,          //
-       const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer sin2phi,        //
-       const py::buffer cos2phi,        //
-       const py::buffer vec,            //
-       py::buffer prod,                 //
-       const py::object mpi4py_comm     //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info sin2phi_info = sin2phi.request();
-      py::buffer_info cos2phi_info = cos2phi.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
-
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *sin2phi_ptr =
-          reinterpret_cast<const dfloat *>(sin2phi_info.ptr);
-      const dfloat *cos2phi_ptr =
-          reinterpret_cast<const dfloat *>(cos2phi_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
-
-      const MPI_Comm comm =
-          (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
-              ->ob_mpi;
-
-      PLO_rmult_IQU(          //
-          new_npix,           //
-          nsamples,           //
-          pointings_ptr,      //
-          pointings_flag_ptr, //
-          sin2phi_ptr,        //
-          cos2phi_ptr,        //
-          vec_ptr,            //
-          prod_ptr,           //
-          comm                //
-      );
-
-      return;
-    }; // numpy_bind_PLO_rmult_IQU()
-
-PYBIND11_MODULE(PointingLO_tools, m) {
+NB_MODULE(PointingLO_tools, m) {
   m.doc() = "PointingLO_tools";
-  m.def("PLO_mult_I", numpy_bind_PLO_mult_I<py::array_t, int32_t, float>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_I", numpy_bind_PLO_mult_I<py::array_t, int32_t, double>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_I", numpy_bind_PLO_mult_I<py::array_t, int64_t, float>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_I", numpy_bind_PLO_mult_I<py::array_t, int64_t, double>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_QU", numpy_bind_PLO_mult_QU<py::array_t, int32_t, float>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_QU", numpy_bind_PLO_mult_QU<py::array_t, int32_t, double>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_QU", numpy_bind_PLO_mult_QU<py::array_t, int64_t, float>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_QU", numpy_bind_PLO_mult_QU<py::array_t, int64_t, double>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_IQU", numpy_bind_PLO_mult_IQU<py::array_t, int32_t, float>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_IQU", numpy_bind_PLO_mult_IQU<py::array_t, int32_t, double>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_IQU", numpy_bind_PLO_mult_IQU<py::array_t, int64_t, float>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
-  m.def("PLO_mult_IQU", numpy_bind_PLO_mult_IQU<py::array_t, int64_t, double>,
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert()            //
-  );
 
-  m.def("PLO_rmult_I", numpy_bind_PLO_rmult_I<py::array_t, int32_t, float>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_I", numpy_bind_PLO_rmult_I<py::array_t, int32_t, double>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_I", numpy_bind_PLO_rmult_I<py::array_t, int64_t, float>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_I", numpy_bind_PLO_rmult_I<py::array_t, int64_t, double>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_QU", numpy_bind_PLO_rmult_QU<py::array_t, int32_t, float>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_QU", numpy_bind_PLO_rmult_QU<py::array_t, int32_t, double>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_QU", numpy_bind_PLO_rmult_QU<py::array_t, int64_t, float>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_QU", numpy_bind_PLO_rmult_QU<py::array_t, int64_t, double>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_IQU", numpy_bind_PLO_rmult_IQU<py::array_t, int32_t, float>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_IQU", numpy_bind_PLO_rmult_IQU<py::array_t, int32_t, double>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_IQU", numpy_bind_PLO_rmult_IQU<py::array_t, int64_t, float>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
-  m.def("PLO_rmult_IQU", numpy_bind_PLO_rmult_IQU<py::array_t, int64_t, double>,
-        py::arg("new_npix"),                   //
-        py::arg("nsamples"),                   //
-        py::arg("pointings").noconvert(),      //
-        py::arg("pointings_flag").noconvert(), //
-        py::arg("sin2phi").noconvert(),        //
-        py::arg("cos2phi").noconvert(),        //
-        py::arg("vec").noconvert(),            //
-        py::arg("prod").noconvert(),           //
-        py::arg("comm").noconvert()            //
-  );
+  register_PointingLO<int64_t, double, nb::device::cpu>(m);
+  register_PointingLO<int32_t, double, nb::device::cpu>(m);
+  register_PointingLO<int64_t, float, nb::device::cpu>(m);
+  register_PointingLO<int32_t, float, nb::device::cpu>(m);
 }

--- a/brahmap/_extensions/compute_weights.cpp
+++ b/brahmap/_extensions/compute_weights.cpp
@@ -1,8 +1,7 @@
 #include <cmath>
-#include <functional>
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #ifndef _DISABLE_OMP
 #include <omp.h>
@@ -10,7 +9,7 @@
 
 #include "mpi_utils.hpp"
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 template <typename dint, typename dfloat>
 dint compute_weights_pol_I(                 //
@@ -52,7 +51,7 @@ dint compute_weights_pol_I(                 //
       pixel_flag[idx] = true;
       ++new_npix;
     } // if
-  }   // for
+  } // for
 
   return new_npix;
 
@@ -249,600 +248,212 @@ dint get_pixel_mask_pol(                           //
 
 } // get_pixel_mask_pol()
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint,
-          typename dfloat>
-std::function<dint(                       //
-    const ssize_t npix,                   //
-    const ssize_t nsamples,               //
-    const buffer_t<dint> pointings,       //
-    const buffer_t<bool> pointings_flag,  //
-    const buffer_t<dfloat> noise_weights, //
-    buffer_t<dint> hit_counts,            //
-    buffer_t<dfloat> weighted_counts,     //
-    buffer_t<dint> observed_pixels,       //
-    buffer_t<dint> __old2new_pixel,       //
-    buffer_t<bool> pixel_flag,            //
-    const py::object mpi4py_comm          //
-    )>
-    numpy_bind_compute_weights_pol_I =  //
-    [](const ssize_t npix,              //
-       const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer noise_weights,  //
-       py::buffer hit_counts,           //
-       py::buffer weighted_counts,      //
-       py::buffer observed_pixels,      //
-       py::buffer __old2new_pixel,      //
-       py::buffer pixel_flag,           //
-       const py::object mpi4py_comm     //
-       ) -> dint {
-  py::buffer_info pointings_info = pointings.request();
-  py::buffer_info pointings_flags_info = pointings_flag.request();
-  py::buffer_info noise_weights_info = noise_weights.request();
-  py::buffer_info hit_counts_info = hit_counts.request();
-  py::buffer_info weighted_counts_info = weighted_counts.request();
-  py::buffer_info observed_pixels_info = observed_pixels.request();
-  py::buffer_info __old2new_pixel_info = __old2new_pixel.request();
-  py::buffer_info pixel_flag_info = pixel_flag.request();
+template <typename dint, typename dfloat, typename device> //
+void register_compute_weights(nb::module_ &m) {
+  using arr_dint = nb::ndarray<dint, nb::ndim<1>, device, nb::c_contig>;
+  using arr_dfloat = nb::ndarray<dfloat, nb::ndim<1>, device, nb::c_contig>;
+  using arr_bool = nb::ndarray<bool, nb::ndim<1>, device, nb::c_contig>;
 
-  const dint *pointings_ptr =
-      reinterpret_cast<const dint *>(pointings_info.ptr);
-  const bool *pointings_flags_ptr =
-      reinterpret_cast<const bool *>(pointings_flags_info.ptr);
-  const dfloat *noise_weights_ptr =
-      reinterpret_cast<const dfloat *>(noise_weights_info.ptr);
-  dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
-  dfloat *weighted_counts_ptr =
-      reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
-  dint *observed_pixels_ptr =
-      reinterpret_cast<dint *>(observed_pixels_info.ptr);
-  dint *__old2new_pixel_ptr =
-      reinterpret_cast<dint *>(__old2new_pixel_info.ptr);
-  bool *pixel_flag_ptr = reinterpret_cast<bool *>(pixel_flag_info.ptr);
+  auto get_comm = [](const nb::object &mpi4py_comm) -> MPI_Comm {
+    return (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
+        ->ob_mpi;
+  };
 
-  const MPI_Comm comm =
-      (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))->ob_mpi;
-
-  dint new_npix = compute_weights_pol_I( //
-      npix,                              //
-      nsamples,                          //
-      pointings_ptr,                     //
-      pointings_flags_ptr,               //
-      noise_weights_ptr,                 //
-      hit_counts_ptr,                    //
-      weighted_counts_ptr,               //
-      observed_pixels_ptr,               //
-      __old2new_pixel_ptr,               //
-      pixel_flag_ptr,                    //
-      comm                               //
+  m.def(
+      "compute_weights_pol_I",            //
+      [get_comm](                         //
+          const ssize_t npix,             //
+          const ssize_t nsamples,         //
+          const arr_dint pointings,       //
+          const arr_bool pointings_flag,  //
+          const arr_dfloat noise_weights, //
+          arr_dint hit_counts,            //
+          arr_dfloat weighted_counts,     //
+          arr_dint observed_pixels,       //
+          arr_dint __old2new_pixel,       //
+          arr_bool pixel_flag,            //
+          const nb::object mpi4py_comm    //
+          ) -> dint {
+        return compute_weights_pol_I( //
+            npix,                     //
+            nsamples,                 //
+            pointings.data(),         //
+            pointings_flag.data(),    //
+            noise_weights.data(),     //
+            hit_counts.data(),        //
+            weighted_counts.data(),   //
+            observed_pixels.data(),   //
+            __old2new_pixel.data(),   //
+            pixel_flag.data(),        //
+            get_comm(mpi4py_comm)     //
+        );
+      },
+      nb::arg("npix"),                        //
+      nb::arg("nsamples"),                    //
+      nb::arg("pointings").noconvert(),       //
+      nb::arg("pointings_flag").noconvert(),  //
+      nb::arg("noise_weights").noconvert(),   //
+      nb::arg("hit_counts").noconvert(),      //
+      nb::arg("weighted_counts").noconvert(), //
+      nb::arg("observed_pixels").noconvert(), //
+      nb::arg("__old2new_pixel").noconvert(), //
+      nb::arg("pixel_flag").noconvert(),      //
+      nb::arg("comm").noconvert()             //
   );
 
-  return new_npix;
-}; // numpy_bind_compute_weights_pol_I
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                        //
-    const ssize_t npix,                    //
-    const ssize_t nsamples,                //
-    const buffer_t<dint> pointings,        //
-    const buffer_t<bool> pointings_flag,   //
-    const buffer_t<dfloat> noise_weights,  //
-    const buffer_t<dfloat> pol_angles,     //
-    buffer_t<dint> hit_counts,             //
-    buffer_t<dfloat> weighted_counts,      //
-    buffer_t<dfloat> sin2phi,              //
-    buffer_t<dfloat> cos2phi,              //
-    buffer_t<dfloat> weighted_sin_sq,      //
-    buffer_t<dfloat> weighted_cos_sq,      //
-    buffer_t<dfloat> weighted_sincos,      //
-    buffer_t<dfloat> one_over_determinant, //
-    const py::object mpi4py_comm           //
-    )>
-    numpy_bind_compute_weights_pol_QU = //
-    [](const ssize_t npix,              //
-       const ssize_t nsamples,          //
-       const py::buffer pointings,      //
-       const py::buffer pointings_flag, //
-       const py::buffer noise_weights,  //
-       const py::buffer pol_angles,     //
-       py::buffer hit_counts,           //
-       py::buffer weighted_counts,      //
-       py::buffer sin2phi,              //
-       py::buffer cos2phi,              //
-       py::buffer weighted_sin_sq,      //
-       py::buffer weighted_cos_sq,      //
-       py::buffer weighted_sincos,      //
-       py::buffer one_over_determinant, //
-       const py::object mpi4py_comm     //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info noise_weights_info = noise_weights.request();
-      py::buffer_info pol_angles_info = pol_angles.request();
-      py::buffer_info hit_counts_info = hit_counts.request();
-      py::buffer_info weighted_counts_info = weighted_counts.request();
-      py::buffer_info sin2phi_info = sin2phi.request();
-      py::buffer_info cos2phi_info = cos2phi.request();
-      py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
-      py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
-      py::buffer_info weighted_sincos_info = weighted_sincos.request();
-      py::buffer_info one_over_determinant_info =
-          one_over_determinant.request();
-
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *noise_weights_ptr =
-          reinterpret_cast<const dfloat *>(noise_weights_info.ptr);
-      const dfloat *pol_angles_ptr =
-          reinterpret_cast<const dfloat *>(pol_angles_info.ptr);
-      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
-      dfloat *weighted_counts_ptr =
-          reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
-      dfloat *sin2phi_ptr = reinterpret_cast<dfloat *>(sin2phi_info.ptr);
-      dfloat *cos2phi_ptr = reinterpret_cast<dfloat *>(cos2phi_info.ptr);
-      dfloat *weighted_sin_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_sin_sq_info.ptr);
-      dfloat *weighted_cos_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_cos_sq_info.ptr);
-      dfloat *weighted_sincos_ptr =
-          reinterpret_cast<dfloat *>(weighted_sincos_info.ptr);
-      dfloat *one_over_determinant_ptr =
-          reinterpret_cast<dfloat *>(one_over_determinant_info.ptr);
-
-      const MPI_Comm comm =
-          (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
-              ->ob_mpi;
-
-      compute_weights_pol_QU(       //
-          npix,                     //
-          nsamples,                 //
-          pointings_ptr,            //
-          pointings_flag_ptr,       //
-          noise_weights_ptr,        //
-          pol_angles_ptr,           //
-          hit_counts_ptr,           //
-          weighted_counts_ptr,      //
-          sin2phi_ptr,              //
-          cos2phi_ptr,              //
-          weighted_sin_sq_ptr,      //
-          weighted_cos_sq_ptr,      //
-          weighted_sincos_ptr,      //
-          one_over_determinant_ptr, //
-          comm                      //
-      );
-
-      return;
-    }; // numpy_bind_compute_weights_pol_QU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint,
-          typename dfloat>
-std::function<void(                        //
-    const ssize_t npix,                    //
-    const ssize_t nsamples,                //
-    const buffer_t<dint> pointings,        //
-    const buffer_t<bool> pointings_flag,   //
-    const buffer_t<dfloat> noise_weights,  //
-    const buffer_t<dfloat> pol_angles,     //
-    buffer_t<dint> hit_counts,             //
-    buffer_t<dfloat> weighted_counts,      //
-    buffer_t<dfloat> sin2phi,              //
-    buffer_t<dfloat> cos2phi,              //
-    buffer_t<dfloat> weighted_sin_sq,      //
-    buffer_t<dfloat> weighted_cos_sq,      //
-    buffer_t<dfloat> weighted_sincos,      //
-    buffer_t<dfloat> weighted_sin,         //
-    buffer_t<dfloat> weighted_cos,         //
-    buffer_t<dfloat> one_over_determinant, //
-    const py::object mpi4py_comm           //
-    )>
-    numpy_bind_compute_weights_pol_IQU = //
-    [](const ssize_t npix,               //
-       const ssize_t nsamples,           //
-       const py::buffer pointings,       //
-       const py::buffer pointings_flag,  //
-       const py::buffer noise_weights,   //
-       const py::buffer pol_angles,      //
-       py::buffer hit_counts,            //
-       py::buffer weighted_counts,       //
-       py::buffer sin2phi,               //
-       py::buffer cos2phi,               //
-       py::buffer weighted_sin_sq,       //
-       py::buffer weighted_cos_sq,       //
-       py::buffer weighted_sincos,       //
-       py::buffer weighted_sin,          //
-       py::buffer weighted_cos,          //
-       py::buffer one_over_determinant,  //
-       const py::object mpi4py_comm      //
-    ) {
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-      py::buffer_info noise_weights_info = noise_weights.request();
-      py::buffer_info pol_angles_info = pol_angles.request();
-      py::buffer_info hit_counts_info = hit_counts.request();
-      py::buffer_info weighted_counts_info = weighted_counts.request();
-      py::buffer_info sin2phi_info = sin2phi.request();
-      py::buffer_info cos2phi_info = cos2phi.request();
-      py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
-      py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
-      py::buffer_info weighted_sincos_info = weighted_sincos.request();
-      py::buffer_info weighted_sin_info = weighted_sin.request();
-      py::buffer_info weighted_cos_info = weighted_cos.request();
-      py::buffer_info one_over_determinant_info =
-          one_over_determinant.request();
-
-      const dint *pointings_ptr =
-          reinterpret_cast<const dint *>(pointings_info.ptr);
-      const bool *pointings_flag_ptr =
-          reinterpret_cast<const bool *>(pointings_flag_info.ptr);
-      const dfloat *noise_weights_ptr =
-          reinterpret_cast<const dfloat *>(noise_weights_info.ptr);
-      const dfloat *pol_angles_ptr =
-          reinterpret_cast<const dfloat *>(pol_angles_info.ptr);
-      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
-      dfloat *weighted_counts_ptr =
-          reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
-      dfloat *sin2phi_ptr = reinterpret_cast<dfloat *>(sin2phi_info.ptr);
-      dfloat *cos2phi_ptr = reinterpret_cast<dfloat *>(cos2phi_info.ptr);
-      dfloat *weighted_sin_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_sin_sq_info.ptr);
-      dfloat *weighted_cos_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_cos_sq_info.ptr);
-      dfloat *weighted_sincos_ptr =
-          reinterpret_cast<dfloat *>(weighted_sincos_info.ptr);
-      dfloat *weighted_sin_ptr =
-          reinterpret_cast<dfloat *>(weighted_sin_info.ptr);
-      dfloat *weighted_cos_ptr =
-          reinterpret_cast<dfloat *>(weighted_cos_info.ptr);
-      dfloat *one_over_determinant_ptr =
-          reinterpret_cast<dfloat *>(one_over_determinant_info.ptr);
-
-      const MPI_Comm comm =
-          (reinterpret_cast<const PyMPICommObject *>(mpi4py_comm.ptr()))
-              ->ob_mpi;
-
-      compute_weights_pol_IQU(      //
-          npix,                     //
-          nsamples,                 //
-          pointings_ptr,            //
-          pointings_flag_ptr,       //
-          noise_weights_ptr,        //
-          pol_angles_ptr,           //
-          hit_counts_ptr,           //
-          weighted_counts_ptr,      //
-          sin2phi_ptr,              //
-          cos2phi_ptr,              //
-          weighted_sin_sq_ptr,      //
-          weighted_cos_sq_ptr,      //
-          weighted_sincos_ptr,      //
-          weighted_sin_ptr,         //
-          weighted_cos_ptr,         //
-          one_over_determinant_ptr, //
-          comm                      //
-      );
-
-      return;
-    }; // numpy_bind_compute_weights_pol_IQU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint,
-          typename dfloat>
-std::function<dint(                              //
-    const int solver_type,                       //
-    const ssize_t npix,                          //
-    const dfloat threshold,                      //
-    const buffer_t<dint> hit_counts,             //
-    const buffer_t<dfloat> one_over_determinant, //
-    buffer_t<dint> observed_pixels,              //
-    buffer_t<dint> __old2new_pixel,              //
-    buffer_t<bool> pixel_flag                    //
-    )>
-    numpy_bind_get_pixel_mask_pol =           //
-    [](const int solver_type,                 //
-       const ssize_t npix,                    //
-       const dfloat threshold,                //
-       const py::buffer hit_counts,           //
-       const py::buffer one_over_determinant, //
-       py::buffer observed_pixels,            //
-       py::buffer __old2new_pixel,            //
-       py::buffer pixel_flag                  //
-       ) -> dint {
-  py::buffer_info hit_counts_info = hit_counts.request();
-  py::buffer_info one_over_determinant_info = one_over_determinant.request();
-  py::buffer_info observed_pixels_info = observed_pixels.request();
-  py::buffer_info __old2new_pixel_info = __old2new_pixel.request();
-  py::buffer_info pixel_flag_info = pixel_flag.request();
-
-  const dint *hit_counts_ptr =
-      reinterpret_cast<const dint *>(hit_counts_info.ptr);
-  const dfloat *one_over_determinant_ptr =
-      reinterpret_cast<const dfloat *>(one_over_determinant_info.ptr);
-  dint *observed_pixels_ptr =
-      reinterpret_cast<dint *>(observed_pixels_info.ptr);
-  dint *__old2new_pixel_ptr =
-      reinterpret_cast<dint *>(__old2new_pixel_info.ptr);
-  bool *pixel_flag_ptr = reinterpret_cast<bool *>(pixel_flag_info.ptr);
-
-  dint new_npix = get_pixel_mask_pol( //
-      solver_type,                    //
-      npix,                           //
-      threshold,                      //
-      hit_counts_ptr,                 //
-      one_over_determinant_ptr,       //
-      observed_pixels_ptr,            //
-      __old2new_pixel_ptr,            //
-      pixel_flag_ptr                  //
+  m.def(
+      "compute_weights_pol_QU",            //
+      [get_comm](                          //
+          const ssize_t npix,              //
+          const ssize_t nsamples,          //
+          const arr_dint pointings,        //
+          const arr_bool pointings_flag,   //
+          const arr_dfloat noise_weights,  //
+          const arr_dfloat pol_angles,     //
+          arr_dint hit_counts,             //
+          arr_dfloat weighted_counts,      //
+          arr_dfloat sin2phi,              //
+          arr_dfloat cos2phi,              //
+          arr_dfloat weighted_sin_sq,      //
+          arr_dfloat weighted_cos_sq,      //
+          arr_dfloat weighted_sincos,      //
+          arr_dfloat one_over_determinant, //
+          const nb::object mpi4py_comm     //
+      ) {
+        compute_weights_pol_QU(          //
+            npix,                        //
+            nsamples,                    //
+            pointings.data(),            //
+            pointings_flag.data(),       //
+            noise_weights.data(),        //
+            pol_angles.data(),           //
+            hit_counts.data(),           //
+            weighted_counts.data(),      //
+            sin2phi.data(),              //
+            cos2phi.data(),              //
+            weighted_sin_sq.data(),      //
+            weighted_cos_sq.data(),      //
+            weighted_sincos.data(),      //
+            one_over_determinant.data(), //
+            get_comm(mpi4py_comm)        //
+        );
+      },
+      nb::arg("npix"),                             //
+      nb::arg("nsamples"),                         //
+      nb::arg("pointings").noconvert(),            //
+      nb::arg("pointings_flag").noconvert(),       //
+      nb::arg("noise_weights").noconvert(),        //
+      nb::arg("pol_angles").noconvert(),           //
+      nb::arg("hit_counts").noconvert(),           //
+      nb::arg("weighted_counts").noconvert(),      //
+      nb::arg("sin2phi").noconvert(),              //
+      nb::arg("cos2phi").noconvert(),              //
+      nb::arg("weighted_sin_sq").noconvert(),      //
+      nb::arg("weighted_cos_sq").noconvert(),      //
+      nb::arg("weighted_sincos").noconvert(),      //
+      nb::arg("one_over_determinant").noconvert(), //
+      nb::arg("comm").noconvert()                  //
   );
 
-  return new_npix;
-}; // numpy_bind_get_pixel_mask_pol()
+  m.def(
+      "compute_weights_pol_IQU",           //
+      [get_comm](                          //
+          const ssize_t npix,              //
+          const ssize_t nsamples,          //
+          const arr_dint pointings,        //
+          const arr_bool pointings_flag,   //
+          const arr_dfloat noise_weights,  //
+          const arr_dfloat pol_angles,     //
+          arr_dint hit_counts,             //
+          arr_dfloat weighted_counts,      //
+          arr_dfloat sin2phi,              //
+          arr_dfloat cos2phi,              //
+          arr_dfloat weighted_sin_sq,      //
+          arr_dfloat weighted_cos_sq,      //
+          arr_dfloat weighted_sincos,      //
+          arr_dfloat weighted_sin,         //
+          arr_dfloat weighted_cos,         //
+          arr_dfloat one_over_determinant, //
+          const nb::object mpi4py_comm     //
+      ) {
+        compute_weights_pol_IQU(         //
+            npix,                        //
+            nsamples,                    //
+            pointings.data(),            //
+            pointings_flag.data(),       //
+            noise_weights.data(),        //
+            pol_angles.data(),           //
+            hit_counts.data(),           //
+            weighted_counts.data(),      //
+            sin2phi.data(),              //
+            cos2phi.data(),              //
+            weighted_sin_sq.data(),      //
+            weighted_cos_sq.data(),      //
+            weighted_sincos.data(),      //
+            weighted_sin.data(),         //
+            weighted_cos.data(),         //
+            one_over_determinant.data(), //
+            get_comm(mpi4py_comm)        //
+        );
+      },
+      nb::arg("npix"),                             //
+      nb::arg("nsamples"),                         //
+      nb::arg("pointings").noconvert(),            //
+      nb::arg("pointings_flag").noconvert(),       //
+      nb::arg("noise_weights").noconvert(),        //
+      nb::arg("pol_angles").noconvert(),           //
+      nb::arg("hit_counts").noconvert(),           //
+      nb::arg("weighted_counts").noconvert(),      //
+      nb::arg("sin2phi").noconvert(),              //
+      nb::arg("cos2phi").noconvert(),              //
+      nb::arg("weighted_sin_sq").noconvert(),      //
+      nb::arg("weighted_cos_sq").noconvert(),      //
+      nb::arg("weighted_sincos").noconvert(),      //
+      nb::arg("weighted_sin").noconvert(),         //
+      nb::arg("weighted_cos").noconvert(),         //
+      nb::arg("one_over_determinant").noconvert(), //
+      nb::arg("comm").noconvert()                  //
+  );
 
-PYBIND11_MODULE(compute_weights, m) {
+  m.def(
+      "get_pixel_mask_pol",                      //
+      [](                                        //
+          const int solver_type,                 //
+          const ssize_t npix,                    //
+          const dfloat threshold,                //
+          const arr_dint hit_counts,             //
+          const arr_dfloat one_over_determinant, //
+          arr_dint observed_pixels,              //
+          arr_dint __old2new_pixel,              //
+          arr_bool pixel_flag                    //
+          ) -> dint {
+        return get_pixel_mask_pol(       //
+            solver_type,                 //
+            npix,                        //
+            threshold,                   //
+            hit_counts.data(),           //
+            one_over_determinant.data(), //
+            observed_pixels.data(),      //
+            __old2new_pixel.data(),      //
+            pixel_flag.data()            //
+        );
+      },
+      nb::arg("solver_type"),                      //
+      nb::arg("npix"),                             //
+      nb::arg("threshold"),                        //
+      nb::arg("hit_counts").noconvert(),           //
+      nb::arg("one_over_determinant").noconvert(), //
+      nb::arg("observed_pixels").noconvert(),      //
+      nb::arg("__old2new_pixel").noconvert(),      //
+      nb::arg("pixel_flag").noconvert()            //
+  );
+}
+
+NB_MODULE(compute_weights, m) {
   m.doc() = "compute_weights";
-  m.def("compute_weights_pol_I",
-        numpy_bind_compute_weights_pol_I<py::array_t, int32_t, float>,
-        py::arg("npix"),                        //
-        py::arg("nsamples"),                    //
-        py::arg("pointings").noconvert(),       //
-        py::arg("pointings_flag").noconvert(),  //
-        py::arg("noise_weights").noconvert(),   //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert(), //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("__old2new_pixel").noconvert(), //
-        py::arg("pixel_flag").noconvert(),      //
-        py::arg("comm").noconvert()             //
-  );
-  m.def("compute_weights_pol_I",
-        numpy_bind_compute_weights_pol_I<py::array_t, int64_t, float>,
-        py::arg("npix"),                        //
-        py::arg("nsamples"),                    //
-        py::arg("pointings").noconvert(),       //
-        py::arg("pointings_flag").noconvert(),  //
-        py::arg("noise_weights").noconvert(),   //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert(), //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("__old2new_pixel").noconvert(), //
-        py::arg("pixel_flag").noconvert(),      //
-        py::arg("comm").noconvert()             //
-  );
-  m.def("compute_weights_pol_I",
-        numpy_bind_compute_weights_pol_I<py::array_t, int32_t, double>,
-        py::arg("npix"),                        //
-        py::arg("nsamples"),                    //
-        py::arg("pointings").noconvert(),       //
-        py::arg("pointings_flag").noconvert(),  //
-        py::arg("noise_weights").noconvert(),   //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert(), //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("__old2new_pixel").noconvert(), //
-        py::arg("pixel_flag").noconvert(),      //
-        py::arg("comm").noconvert()             //
-  );
-  m.def("compute_weights_pol_I",
-        numpy_bind_compute_weights_pol_I<py::array_t, int64_t, double>,
-        py::arg("npix"),                        //
-        py::arg("nsamples"),                    //
-        py::arg("pointings").noconvert(),       //
-        py::arg("pointings_flag").noconvert(),  //
-        py::arg("noise_weights").noconvert(),   //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert(), //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("__old2new_pixel").noconvert(), //
-        py::arg("pixel_flag").noconvert(),      //
-        py::arg("comm").noconvert()             //
-  );
 
-  m.def("compute_weights_pol_QU",
-        numpy_bind_compute_weights_pol_QU<py::array_t, int32_t, float>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_QU",
-        numpy_bind_compute_weights_pol_QU<py::array_t, int64_t, float>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_QU",
-        numpy_bind_compute_weights_pol_QU<py::array_t, int32_t, double>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_QU",
-        numpy_bind_compute_weights_pol_QU<py::array_t, int64_t, double>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_IQU",
-        numpy_bind_compute_weights_pol_IQU<py::array_t, int32_t, float>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("weighted_sin").noconvert(),         //
-        py::arg("weighted_cos").noconvert(),         //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_IQU",
-        numpy_bind_compute_weights_pol_IQU<py::array_t, int64_t, float>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("weighted_sin").noconvert(),         //
-        py::arg("weighted_cos").noconvert(),         //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_IQU",
-        numpy_bind_compute_weights_pol_IQU<py::array_t, int32_t, double>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("weighted_sin").noconvert(),         //
-        py::arg("weighted_cos").noconvert(),         //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("compute_weights_pol_IQU",
-        numpy_bind_compute_weights_pol_IQU<py::array_t, int64_t, double>,
-        py::arg("npix"),                             //
-        py::arg("nsamples"),                         //
-        py::arg("pointings").noconvert(),            //
-        py::arg("pointings_flag").noconvert(),       //
-        py::arg("noise_weights").noconvert(),        //
-        py::arg("pol_angles").noconvert(),           //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("weighted_counts").noconvert(),      //
-        py::arg("sin2phi").noconvert(),              //
-        py::arg("cos2phi").noconvert(),              //
-        py::arg("weighted_sin_sq").noconvert(),      //
-        py::arg("weighted_cos_sq").noconvert(),      //
-        py::arg("weighted_sincos").noconvert(),      //
-        py::arg("weighted_sin").noconvert(),         //
-        py::arg("weighted_cos").noconvert(),         //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("comm").noconvert()                  //
-  );
-
-  m.def("get_pixel_mask_pol",
-        numpy_bind_get_pixel_mask_pol<py::array_t, int32_t, float>,
-        py::arg("solver_type"),                      //
-        py::arg("npix"),                             //
-        py::arg("threshold"),                        //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("observed_pixels").noconvert(),      //
-        py::arg("__old2new_pixel").noconvert(),      //
-        py::arg("pixel_flag").noconvert()            //
-  );
-  m.def("get_pixel_mask_pol",
-        numpy_bind_get_pixel_mask_pol<py::array_t, int64_t, float>,
-        py::arg("solver_type"),                      //
-        py::arg("npix"),                             //
-        py::arg("threshold"),                        //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("observed_pixels").noconvert(),      //
-        py::arg("__old2new_pixel").noconvert(),      //
-        py::arg("pixel_flag").noconvert()            //
-  );
-  m.def("get_pixel_mask_pol",
-        numpy_bind_get_pixel_mask_pol<py::array_t, int32_t, double>,
-        py::arg("solver_type"),                      //
-        py::arg("npix"),                             //
-        py::arg("threshold"),                        //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("observed_pixels").noconvert(),      //
-        py::arg("__old2new_pixel").noconvert(),      //
-        py::arg("pixel_flag").noconvert()            //
-  );
-  m.def("get_pixel_mask_pol",
-        numpy_bind_get_pixel_mask_pol<py::array_t, int64_t, double>,
-        py::arg("solver_type"),                      //
-        py::arg("npix"),                             //
-        py::arg("threshold"),                        //
-        py::arg("hit_counts").noconvert(),           //
-        py::arg("one_over_determinant").noconvert(), //
-        py::arg("observed_pixels").noconvert(),      //
-        py::arg("__old2new_pixel").noconvert(),      //
-        py::arg("pixel_flag").noconvert()            //
-  );
+  register_compute_weights<int64_t, double, nb::device::cpu>(m);
+  register_compute_weights<int32_t, double, nb::device::cpu>(m);
+  register_compute_weights<int64_t, float, nb::device::cpu>(m);
+  register_compute_weights<int32_t, float, nb::device::cpu>(m);
 }

--- a/brahmap/_extensions/mpi_utils.hpp
+++ b/brahmap/_extensions/mpi_utils.hpp
@@ -1,6 +1,7 @@
 #ifndef _MPI_UTILS
 #define _MPI_UTILS
 
+#include <complex>
 #include <mpi.h>
 #include <mpi4py/mpi4py.h>
 

--- a/brahmap/_extensions/repixelization.cpp
+++ b/brahmap/_extensions/repixelization.cpp
@@ -1,11 +1,11 @@
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #ifndef _DISABLE_OMP
 #include <omp.h>
 #endif
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 template <typename dint, typename dfloat>
 void repixelize_pol_I(                      //
@@ -101,341 +101,143 @@ void flag_bad_pixel_samples(              //
   return;
 } //  flag_bad_pixel_samples()
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                       //
-    const ssize_t new_npix,               //
-    const buffer_t<dint> observed_pixels, //
-    buffer_t<dint> hit_counts,            //
-    buffer_t<dfloat> weighted_counts      //
-    )>
-    numpy_bind_repixelize_pol_I =        //
-    [](const ssize_t new_npix,           //
-       const py::buffer observed_pixels, //
-       py::buffer hit_counts,            //
-       py::buffer weighted_counts        //
-    ) {
-      py::buffer_info observed_pixels_info = observed_pixels.request();
-      py::buffer_info hit_counts_info = hit_counts.request();
-      py::buffer_info weighted_counts_info = weighted_counts.request();
+template <typename dint, typename dfloat, typename device> //
+void register_repixelize_pol(nb::module_ &m) {
+  using arr_dint = nb::ndarray<dint, nb::ndim<1>, device, nb::c_contig>;
+  using arr_dfloat = nb::ndarray<dfloat, nb::ndim<1>, device, nb::c_contig>;
 
-      const dint *observed_pixels_ptr =
-          reinterpret_cast<const dint *>(observed_pixels_info.ptr);
-      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
-      dfloat *weighted_counts_ptr =
-          reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
+  m.def(
+      "repixelize_pol_I",                 //
+      [](                                 //
+          const ssize_t new_npix,         //
+          const arr_dint observed_pixels, //
+          arr_dint hit_counts,            //
+          arr_dfloat weighted_counts      //
+      ) {
+        repixelize_pol_I(           //
+            new_npix,               //
+            observed_pixels.data(), //
+            hit_counts.data(),      //
+            weighted_counts.data()  //
+        );
+      },
+      nb::arg("new_npix"),                    //
+      nb::arg("observed_pixels").noconvert(), //
+      nb::arg("hit_counts").noconvert(),      //
+      nb::arg("weighted_counts").noconvert()  //
+  );
 
-      repixelize_pol_I(        //
-          new_npix,            //
-          observed_pixels_ptr, //
-          hit_counts_ptr,      //
-          weighted_counts_ptr  //
-      );
-    }; // numpy_bind_repixelize_pol_I()
+  m.def(
+      "repixelize_pol_QU",                //
+      [](                                 //
+          const ssize_t new_npix,         //
+          const arr_dint observed_pixels, //
+          arr_dint hit_counts,            //
+          arr_dfloat weighted_counts,     //
+          arr_dfloat weighted_sin_sq,     //
+          arr_dfloat weighted_cos_sq,     //
+          arr_dfloat weighted_sincos,     //
+          arr_dfloat one_over_determinant //
+      ) {
+        repixelize_pol_QU(              //
+            new_npix,                   //
+            observed_pixels.data(),     //
+            hit_counts.data(),          //
+            weighted_counts.data(),     //
+            weighted_sin_sq.data(),     //
+            weighted_cos_sq.data(),     //
+            weighted_sincos.data(),     //
+            one_over_determinant.data() //
+        );
+      },
+      nb::arg("new_npix"),                        //
+      nb::arg("observed_pixels").noconvert(),     //
+      nb::arg("hit_counts").noconvert(),          //
+      nb::arg("weighted_counts").noconvert(),     //
+      nb::arg("weighted_sin_sq").noconvert(),     //
+      nb::arg("weighted_cos_sq").noconvert(),     //
+      nb::arg("weighted_sincos").noconvert(),     //
+      nb::arg("one_over_determinant").noconvert() //
+  );
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                       //
-    const ssize_t new_npix,               //
-    const buffer_t<dint> observed_pixels, //
-    buffer_t<dint> hit_counts,            //
-    buffer_t<dfloat> weighted_counts,     //
-    buffer_t<dfloat> weighted_sin_sq,     //
-    buffer_t<dfloat> weighted_cos_sq,     //
-    buffer_t<dfloat> weighted_sincos,     //
-    buffer_t<dfloat> one_over_determinant //
-    )>
-    numpy_bind_repixelize_pol_QU =       //
-    [](const ssize_t new_npix,           //
-       const py::buffer observed_pixels, //
-       py::buffer hit_counts,            //
-       py::buffer weighted_counts,       //
-       py::buffer weighted_sin_sq,       //
-       py::buffer weighted_cos_sq,       //
-       py::buffer weighted_sincos,       //
-       py::buffer one_over_determinant   //
-    ) {
-      py::buffer_info observed_pixels_info = observed_pixels.request();
-      py::buffer_info hit_counts_info = hit_counts.request();
-      py::buffer_info weighted_counts_info = weighted_counts.request();
-      py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
-      py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
-      py::buffer_info weighted_sincos_info = weighted_sincos.request();
-      py::buffer_info one_over_determinant_info =
-          one_over_determinant.request();
+  m.def(
+      "repixelize_pol_IQU",               //
+      [](                                 //
+          const ssize_t new_npix,         //
+          const arr_dint observed_pixels, //
+          arr_dint hit_counts,            //
+          arr_dfloat weighted_counts,     //
+          arr_dfloat weighted_sin_sq,     //
+          arr_dfloat weighted_cos_sq,     //
+          arr_dfloat weighted_sincos,     //
+          arr_dfloat weighted_sin,        //
+          arr_dfloat weighted_cos,        //
+          arr_dfloat one_over_determinant //
+      ) {
+        repixelize_pol_IQU(             //
+            new_npix,                   //
+            observed_pixels.data(),     //
+            hit_counts.data(),          //
+            weighted_counts.data(),     //
+            weighted_sin_sq.data(),     //
+            weighted_cos_sq.data(),     //
+            weighted_sincos.data(),     //
+            weighted_sin.data(),        //
+            weighted_cos.data(),        //
+            one_over_determinant.data() //
+        );
+      },
+      nb::arg("new_npix"),                        //
+      nb::arg("observed_pixels").noconvert(),     //
+      nb::arg("hit_counts").noconvert(),          //
+      nb::arg("weighted_counts").noconvert(),     //
+      nb::arg("weighted_sin_sq").noconvert(),     //
+      nb::arg("weighted_cos_sq").noconvert(),     //
+      nb::arg("weighted_sincos").noconvert(),     //
+      nb::arg("weighted_sin").noconvert(),        //
+      nb::arg("weighted_cos").noconvert(),        //
+      nb::arg("one_over_determinant").noconvert() //
+  );
+}
 
-      const dint *observed_pixels_ptr =
-          reinterpret_cast<const dint *>(observed_pixels_info.ptr);
-      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
-      dfloat *weighted_counts_ptr =
-          reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
-      dfloat *weighted_sin_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_sin_sq_info.ptr);
-      dfloat *weighted_cos_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_cos_sq_info.ptr);
-      dfloat *weighted_sincos_ptr =
-          reinterpret_cast<dfloat *>(weighted_sincos_info.ptr);
-      dfloat *one_over_determinant_ptr =
-          reinterpret_cast<dfloat *>(one_over_determinant_info.ptr);
+template <typename dint, typename device> //
+void register_flag_bad_pixel_samples(nb::module_ &m) {
+  using arr_dint = nb::ndarray<dint, nb::ndim<1>, device, nb::c_contig>;
+  using arr_bool = nb::ndarray<bool, nb::ndim<1>, device, nb::c_contig>;
 
-      repixelize_pol_QU(           //
-          new_npix,                //
-          observed_pixels_ptr,     //
-          hit_counts_ptr,          //
-          weighted_counts_ptr,     //
-          weighted_sin_sq_ptr,     //
-          weighted_cos_sq_ptr,     //
-          weighted_sincos_ptr,     //
-          one_over_determinant_ptr //
-      );
-    }; // numpy_bind_repixelize_pol_QU()
+  m.def(
+      "flag_bad_pixel_samples",         //
+      [](                               //
+          const ssize_t nsamples,       //
+          const arr_bool pixel_flag,    //
+          const arr_dint old2new_pixel, //
+          arr_dint pointings,           //
+          arr_bool pointings_flag       //
+      ) {
+        flag_bad_pixel_samples(   //
+            nsamples,             //
+            pixel_flag.data(),    //
+            old2new_pixel.data(), //
+            pointings.data(),     //
+            pointings_flag.data() //
+        );
+      },
+      nb::arg("nsamples"),                  //
+      nb::arg("pixel_flag").noconvert(),    //
+      nb::arg("old2new_pixel").noconvert(), //
+      nb::arg("pointings").noconvert(),     //
+      nb::arg("pointings_flag").noconvert() //
+  );
+}
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint, typename dfloat>
-std::function<void(                       //
-    const ssize_t new_npix,               //
-    const buffer_t<dint> observed_pixels, //
-    buffer_t<dint> hit_counts,            //
-    buffer_t<dfloat> weighted_counts,     //
-    buffer_t<dfloat> weighted_sin_sq,     //
-    buffer_t<dfloat> weighted_cos_sq,     //
-    buffer_t<dfloat> weighted_sincos,     //
-    buffer_t<dfloat> weighted_sin,        //
-    buffer_t<dfloat> weighted_cos,        //
-    buffer_t<dfloat> one_over_determinant //
-    )>
-    numpy_bind_repixelize_pol_IQU =      //
-    [](const ssize_t new_npix,           //
-       const py::buffer observed_pixels, //
-       py::buffer hit_counts,            //
-       py::buffer weighted_counts,       //
-       py::buffer weighted_sin_sq,       //
-       py::buffer weighted_cos_sq,       //
-       py::buffer weighted_sincos,       //
-       py::buffer weighted_sin,          //
-       py::buffer weighted_cos,          //
-       py::buffer one_over_determinant   //
-    ) {
-      py::buffer_info observed_pixels_info = observed_pixels.request();
-      py::buffer_info hit_counts_info = hit_counts.request();
-      py::buffer_info weighted_counts_info = weighted_counts.request();
-      py::buffer_info weighted_sin_sq_info = weighted_sin_sq.request();
-      py::buffer_info weighted_cos_sq_info = weighted_cos_sq.request();
-      py::buffer_info weighted_sincos_info = weighted_sincos.request();
-      py::buffer_info weighted_sin_info = weighted_sin.request();
-      py::buffer_info weighted_cos_info = weighted_cos.request();
-      py::buffer_info one_over_determinant_info =
-          one_over_determinant.request();
-
-      const dint *observed_pixels_ptr =
-          reinterpret_cast<const dint *>(observed_pixels_info.ptr);
-      dint *hit_counts_ptr = reinterpret_cast<dint *>(hit_counts_info.ptr);
-      dfloat *weighted_counts_ptr =
-          reinterpret_cast<dfloat *>(weighted_counts_info.ptr);
-      dfloat *weighted_sin_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_sin_sq_info.ptr);
-      dfloat *weighted_cos_sq_ptr =
-          reinterpret_cast<dfloat *>(weighted_cos_sq_info.ptr);
-      dfloat *weighted_sincos_ptr =
-          reinterpret_cast<dfloat *>(weighted_sincos_info.ptr);
-      dfloat *weighted_sin_ptr =
-          reinterpret_cast<dfloat *>(weighted_sin_info.ptr);
-      dfloat *weighted_cos_ptr =
-          reinterpret_cast<dfloat *>(weighted_cos_info.ptr);
-      dfloat *one_over_determinant_ptr =
-          reinterpret_cast<dfloat *>(one_over_determinant_info.ptr);
-
-      repixelize_pol_IQU(          //
-          new_npix,                //
-          observed_pixels_ptr,     //
-          hit_counts_ptr,          //
-          weighted_counts_ptr,     //
-          weighted_sin_sq_ptr,     //
-          weighted_cos_sq_ptr,     //
-          weighted_sincos_ptr,     //
-          weighted_sin_ptr,        //
-          weighted_cos_ptr,        //
-          one_over_determinant_ptr //
-      );
-    }; // numpy_bind_repixelize_pol_IQU()
-
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dint>
-std::function<void(                     //
-    const ssize_t nsamples,             //
-    const buffer_t<bool> pixel_flag,    //
-    const buffer_t<dint> old2new_pixel, //
-    buffer_t<dint> pointings,           //
-    buffer_t<bool> poitnings_flag       //
-    )>
-    numpy_bind_flag_bad_pixel_samples = //
-    [](const ssize_t nsamples,          //
-       const py::buffer pixel_flag,     //
-       const py::buffer old2new_pixel,  //
-       py::buffer pointings,            //
-       py::buffer pointings_flag        //
-    ) {
-      py::buffer_info pixel_flag_info = pixel_flag.request();
-      py::buffer_info old2new_pixel_info = old2new_pixel.request();
-      py::buffer_info pointings_info = pointings.request();
-      py::buffer_info pointings_flag_info = pointings_flag.request();
-
-      const bool *pixel_flag_ptr =
-          reinterpret_cast<bool *>(pixel_flag_info.ptr);
-      const dint *old2new_pixel_ptr =
-          reinterpret_cast<const dint *>(old2new_pixel_info.ptr);
-      dint *pointings_ptr = reinterpret_cast<dint *>(pointings_info.ptr);
-      bool *pointings_flag_ptr =
-          reinterpret_cast<bool *>(pointings_flag_info.ptr);
-
-      flag_bad_pixel_samples(nsamples, pixel_flag_ptr, old2new_pixel_ptr,
-                             pointings_ptr, pointings_flag_ptr);
-
-      return;
-    }; // numpy_bind_flag_bad_pixel_samples()
-
-PYBIND11_MODULE(repixelize, m) {
+NB_MODULE(repixelize, m) {
   m.doc() = "repixelize";
-  m.def("repixelize_pol_I",
-        numpy_bind_repixelize_pol_I<py::array_t, int32_t, float>,
-        py::arg("new_npix"),                    //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert()  //
-  );
-  m.def("repixelize_pol_I",
-        numpy_bind_repixelize_pol_I<py::array_t, int64_t, float>,
-        py::arg("new_npix"),                    //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert()  //
-  );
-  m.def("repixelize_pol_I",
-        numpy_bind_repixelize_pol_I<py::array_t, int32_t, double>,
-        py::arg("new_npix"),                    //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert()  //
-  );
-  m.def("repixelize_pol_I",
-        numpy_bind_repixelize_pol_I<py::array_t, int64_t, double>,
-        py::arg("new_npix"),                    //
-        py::arg("observed_pixels").noconvert(), //
-        py::arg("hit_counts").noconvert(),      //
-        py::arg("weighted_counts").noconvert()  //
-  );
 
-  m.def("repixelize_pol_QU",
-        numpy_bind_repixelize_pol_QU<py::array_t, int32_t, float>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("repixelize_pol_QU",
-        numpy_bind_repixelize_pol_QU<py::array_t, int64_t, float>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("repixelize_pol_QU",
-        numpy_bind_repixelize_pol_QU<py::array_t, int32_t, double>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("repixelize_pol_QU",
-        numpy_bind_repixelize_pol_QU<py::array_t, int64_t, double>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("one_over_determinant").noconvert() //
-  );
+  register_repixelize_pol<int64_t, double, nb::device::cpu>(m);
+  register_repixelize_pol<int32_t, double, nb::device::cpu>(m);
+  register_repixelize_pol<int64_t, float, nb::device::cpu>(m);
+  register_repixelize_pol<int32_t, float, nb::device::cpu>(m);
 
-  m.def("repixelize_pol_IQU",
-        numpy_bind_repixelize_pol_IQU<py::array_t, int32_t, float>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("weighted_sin").noconvert(),        //
-        py::arg("weighted_cos").noconvert(),        //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("repixelize_pol_IQU",
-        numpy_bind_repixelize_pol_IQU<py::array_t, int64_t, float>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("weighted_sin").noconvert(),        //
-        py::arg("weighted_cos").noconvert(),        //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("repixelize_pol_IQU",
-        numpy_bind_repixelize_pol_IQU<py::array_t, int32_t, double>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("weighted_sin").noconvert(),        //
-        py::arg("weighted_cos").noconvert(),        //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("repixelize_pol_IQU",
-        numpy_bind_repixelize_pol_IQU<py::array_t, int64_t, double>,
-        py::arg("new_npix"),                        //
-        py::arg("observed_pixels").noconvert(),     //
-        py::arg("hit_counts").noconvert(),          //
-        py::arg("weighted_counts").noconvert(),     //
-        py::arg("weighted_sin_sq").noconvert(),     //
-        py::arg("weighted_cos_sq").noconvert(),     //
-        py::arg("weighted_sincos").noconvert(),     //
-        py::arg("weighted_sin").noconvert(),        //
-        py::arg("weighted_cos").noconvert(),        //
-        py::arg("one_over_determinant").noconvert() //
-  );
-  m.def("flag_bad_pixel_samples",
-        numpy_bind_flag_bad_pixel_samples<py::array_t, int32_t>,
-        py::arg("nsamples"),
-        py::arg("pixel_flag").noconvert(),    //
-        py::arg("old2new_pixel").noconvert(), //
-        py::arg("pointings").noconvert(),     //
-        py::arg("pointings_flag").noconvert() //
-  );
-  m.def("flag_bad_pixel_samples",
-        numpy_bind_flag_bad_pixel_samples<py::array_t, int64_t>,
-        py::arg("nsamples"),
-        py::arg("pixel_flag").noconvert(),    //
-        py::arg("old2new_pixel").noconvert(), //
-        py::arg("pointings").noconvert(),     //
-        py::arg("pointings_flag").noconvert() //
-  );
+  register_flag_bad_pixel_samples<int64_t, nb::device::cpu>(m);
+  register_flag_bad_pixel_samples<int32_t, nb::device::cpu>(m);
 }

--- a/brahmap/core/noise_ops_diagonal.py
+++ b/brahmap/core/noise_ops_diagonal.py
@@ -41,11 +41,10 @@ class NoiseCovLO_Diagonal(NoiseCovLinearOperator):
         if isinstance(input, Number) and input_type == "covariance":
             self.__noise_covariance = np.full(shape=size, fill_value=input, dtype=dtype)
         elif input_type == "covariance":
-            self.__noise_covariance = np.asarray(a=input, dtype=dtype)
+            self.__noise_covariance = np.ascontiguousarray(a=input, dtype=dtype)
         elif input_type == "power_spectrum":
-            self.__noise_covariance = scipy.fft.ifft(input).real.astype(
-                dtype=dtype,
-                copy=False,
+            self.__noise_covariance = np.ascontiguousarray(
+                scipy.fft.ifft(input).real, dtype=dtype
             )
 
         MPI_RAISE_EXCEPTION(
@@ -86,14 +85,7 @@ class NoiseCovLO_Diagonal(NoiseCovLinearOperator):
             message=f"Dimensions of `vec` is not compatible with the dimensions of this `InvNoiseCovLO_Diagonal` instance.\nShape of `InvNoiseCovLO_Diagonal` instance: {self.shape}\nShape of `vec`: {vec.shape}",
         )
 
-        if vec.dtype != self.dtype:
-            if MPI_UTILS.rank == 0:
-                warnings.warn(
-                    f"dtype of `vec` will be changed to {self.dtype}",
-                    TypeChangeWarning,
-                )
-            vec = vec.astype(dtype=self.dtype, copy=False)
-
+        vec = np.ascontiguousarray(vec, dtype=self.dtype)
         prod = np.zeros(self.shape[0], dtype=self.dtype)
 
         linalg_tools.multiply_array(
@@ -133,10 +125,12 @@ class InvNoiseCovLO_Diagonal(InvNoiseCovLinearOperator):
                 shape=size, fill_value=1.0 / input, dtype=dtype
             )
         elif input_type == "covariance":
-            self.__inv_noise_cov = 1.0 / np.asarray(a=input, dtype=dtype)
+            self.__inv_noise_cov = np.ascontiguousarray(
+                1.0 / np.asarray(a=input, dtype=dtype), dtype=dtype
+            )
         elif input_type == "power_spectrum":
-            self.__inv_noise_cov = 1.0 / scipy.fft.ifft(input).real.astype(
-                dtype=dtype, copy=False
+            self.__inv_noise_cov = np.ascontiguousarray(
+                1.0 / scipy.fft.ifft(input).real, dtype=dtype
             )
 
         MPI_RAISE_EXCEPTION(
@@ -177,13 +171,7 @@ class InvNoiseCovLO_Diagonal(InvNoiseCovLinearOperator):
             message=f"Dimensions of `vec` is not compatible with the dimensions of this `InvNoiseCovLO_Diagonal` instance.\nShape of `InvNoiseCovLO_Diagonal` instance: {self.shape}\nShape of `vec`: {vec.shape}",
         )
 
-        if vec.dtype != self.dtype:
-            if MPI_UTILS.rank == 0:
-                warnings.warn(
-                    f"dtype of `vec` will be changed to {self.dtype}",
-                    TypeChangeWarning,
-                )
-            vec = vec.astype(dtype=self.dtype, copy=False)
+        vec = np.ascontiguousarray(vec, dtype=self.dtype)
 
         prod = np.zeros(self.shape[0], dtype=self.dtype)
 

--- a/brahmap/math/linalg_tools.cpp
+++ b/brahmap/math/linalg_tools.cpp
@@ -1,13 +1,13 @@
 #include <functional>
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #ifndef _DISABLE_OMP
 #include <omp.h>
 #endif
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 template <typename dfloat>
 void multiply_array(               //
@@ -24,51 +24,35 @@ void multiply_array(               //
   return;
 } // multiply_array()
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dfloat>
-std::function<void(              //
-    const ssize_t nsamples,      //
-    const buffer_t<dfloat> diag, //
-    const buffer_t<dfloat> vec,  //
-    buffer_t<dfloat> prod        //
-    )>
-    numpy_bind_multiply_array = //
-    [](const ssize_t nsamples,  //
-       const py::buffer diag,   //
-       const py::buffer vec,    //
-       py::buffer prod          //
+template <typename dfloat, typename device> //
+void register_multiply_array(nb::module_ &m) {
+  using arr_t = nb::ndarray<dfloat, nb::ndim<1>, device, nb::c_contig>;
 
-    ) {
-      py::buffer_info diag_info = diag.request();
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info prod_info = prod.request();
+  m.def(
+      "multiply_array",           //
+      [](                         //
+          const ssize_t nsamples, //
+          const arr_t diag,       //
+          const arr_t vec,        //
+          arr_t prod              //
+      ) {
+        multiply_array(  //
+            nsamples,    //
+            diag.data(), //
+            vec.data(),  //
+            prod.data()  //
+        );
+      },
+      nb::arg("nsamples"),         //
+      nb::arg("diag").noconvert(), //
+      nb::arg("vec").noconvert(),  //
+      nb::arg("prod").noconvert()  //
+  );
+}
 
-      const dfloat *diag_ptr = reinterpret_cast<const dfloat *>(diag_info.ptr);
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *prod_ptr = reinterpret_cast<dfloat *>(prod_info.ptr);
-
-      multiply_array( //
-          nsamples,   //
-          diag_ptr,   //
-          vec_ptr,    //
-          prod_ptr    //
-      );
-
-      return;
-    }; // numpy_bind_multiply_array()
-
-PYBIND11_MODULE(linalg_tools, m) {
+NB_MODULE(linalg_tools, m) {
   m.doc() = "linalg_tools";
-  m.def("multiply_array", numpy_bind_multiply_array<py::array_t, float>,
-        py::arg("nsamples"), //
-        py::arg("diag"),     //
-        py::arg("vec"),      //
-        py::arg("prod")      //
-  );
-  m.def("multiply_array", numpy_bind_multiply_array<py::array_t, double>,
-        py::arg("nsamples"), //
-        py::arg("diag"),     //
-        py::arg("vec"),      //
-        py::arg("prod")      //
-  );
+
+  register_multiply_array<double, nb::device::cpu>(m);
+  register_multiply_array<float, nb::device::cpu>(m);
 }

--- a/brahmap/math/unary_functions.cpp
+++ b/brahmap/math/unary_functions.cpp
@@ -1,14 +1,13 @@
 #include <cmath>
-#include <functional>
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
 #ifndef _DISABLE_OMP
 #include <omp.h>
 #endif
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 // Alias for the signature of a general unary function pointer.
 // Here the unary function refers to a function that takes one
@@ -31,178 +30,77 @@ void execute(                     //
   return;
 } // execute()
 
-template <template <typename, int = py::array::c_style> class buffer_t,
-          typename dfloat,
-          dfunc<dfloat> unary>
-std::function<void(             //
-    const ssize_t size,         //
-    const buffer_t<dfloat> vec, //
-    buffer_t<dfloat> result     //
-    )>
-    numpy_bind_unary =       //
-    [](const ssize_t size,   //
-       const py::buffer vec, //
-       py::buffer result     //
-    ) {
-      py::buffer_info vec_info = vec.request();
-      py::buffer_info result_info = result.request();
+template <typename dfloat, dfunc<dfloat> unary, typename device> //
+void register_unary_function(nb::module_ &m, const char *name) {
+  using arr_t = nb::ndarray<dfloat, nb::ndim<1>, device, nb::c_contig>;
 
-      const dfloat *vec_ptr = reinterpret_cast<const dfloat *>(vec_info.ptr);
-      dfloat *result_ptr = reinterpret_cast<dfloat *>(result_info.ptr);
+  m.def(
+      name,                   //
+      [](                     //
+          const ssize_t size, //
+          const arr_t vec,    //
+          arr_t result        //
+      ) {
+        execute<dfloat, unary>( //
+            size,               //
+            vec.data(),         //
+            result.data()       //
+        );
+      },
+      nb::arg("size"),              //
+      nb::arg("vec").noconvert(),   //
+      nb::arg("result").noconvert() //
+  );
+}
 
-      execute<dfloat, unary>( //
-          size,               //
-          vec_ptr,            //
-          result_ptr          //
-      );
-
-      return;
-    }; // numpy_bind_unary()
-
-PYBIND11_MODULE(unary_functions, m) {
+NB_MODULE(unary_functions, m) {
   m.doc() = "unary_functions";
 
   // sin function
-  m.def("sin", numpy_bind_unary<py::array_t, float, std::sin>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("sin", numpy_bind_unary<py::array_t, double, std::sin>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  register_unary_function<double, std::sin, nb::device::cpu>(m, "sin");
+  register_unary_function<float, std::sin, nb::device::cpu>(m, "sin");
 
   // cos function
-  m.def("cos", numpy_bind_unary<py::array_t, float, std::cos>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("cos", numpy_bind_unary<py::array_t, double, std::cos>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  register_unary_function<double, std::cos, nb::device::cpu>(m, "cos");
+  register_unary_function<float, std::cos, nb::device::cpu>(m, "cos");
 
   // tan function
-  m.def("tan", numpy_bind_unary<py::array_t, float, std::tan>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("tan", numpy_bind_unary<py::array_t, double, std::tan>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  register_unary_function<double, std::tan, nb::device::cpu>(m, "tan");
+  register_unary_function<float, std::tan, nb::device::cpu>(m, "tan");
 
   // arcsin function
-  m.def("arcsin", numpy_bind_unary<py::array_t, float, std::asin>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("arcsin", numpy_bind_unary<py::array_t, double, std::asin>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  register_unary_function<double, std::asin, nb::device::cpu>(m, "arcsin");
+  register_unary_function<float, std::asin, nb::device::cpu>(m, "arcsin");
 
   // arccos function
-  m.def("arccos", numpy_bind_unary<py::array_t, float, std::acos>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("arccos", numpy_bind_unary<py::array_t, double, std::acos>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  register_unary_function<double, std::acos, nb::device::cpu>(m, "arccos");
+  register_unary_function<float, std::acos, nb::device::cpu>(m, "arccos");
 
   // arctan function
-  m.def("arctan", numpy_bind_unary<py::array_t, float, std::atan>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("arctan", numpy_bind_unary<py::array_t, double, std::atan>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  register_unary_function<double, std::atan, nb::device::cpu>(m, "arctan");
+  register_unary_function<float, std::atan, nb::device::cpu>(m, "arctan");
 
-  // exp function: to compute e**x
-  m.def("exp", numpy_bind_unary<py::array_t, float, std::exp>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("exp", numpy_bind_unary<py::array_t, double, std::exp>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  // exp function
+  register_unary_function<double, std::exp, nb::device::cpu>(m, "exp");
+  register_unary_function<float, std::exp, nb::device::cpu>(m, "exp");
 
-  // exp2 function: to compute 2**x
-  m.def("exp2", numpy_bind_unary<py::array_t, float, std::exp2>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("exp2", numpy_bind_unary<py::array_t, double, std::exp2>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  // exp2 function
+  register_unary_function<double, std::exp2, nb::device::cpu>(m, "exp2");
+  register_unary_function<float, std::exp2, nb::device::cpu>(m, "exp2");
 
-  // log function: natural log
-  m.def("log", numpy_bind_unary<py::array_t, float, std::log>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("log", numpy_bind_unary<py::array_t, double, std::log>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  // log function
+  register_unary_function<double, std::log, nb::device::cpu>(m, "log");
+  register_unary_function<float, std::log, nb::device::cpu>(m, "log");
 
-  // log2 function: log base-2
-  m.def("log2", numpy_bind_unary<py::array_t, float, std::log2>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("log2", numpy_bind_unary<py::array_t, double, std::log2>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  // log2 function
+  register_unary_function<double, std::log2, nb::device::cpu>(m, "log2");
+  register_unary_function<float, std::log2, nb::device::cpu>(m, "log2");
 
-  // sqrt function: square root
-  m.def("sqrt", numpy_bind_unary<py::array_t, float, std::sqrt>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("sqrt", numpy_bind_unary<py::array_t, double, std::sqrt>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  // sqrt function
+  register_unary_function<double, std::sqrt, nb::device::cpu>(m, "sqrt");
+  register_unary_function<float, std::sqrt, nb::device::cpu>(m, "sqrt");
 
-  // cbrt function: cube root
-  m.def("cbrt", numpy_bind_unary<py::array_t, float, std::cbrt>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
-  m.def("cbrt", numpy_bind_unary<py::array_t, double, std::cbrt>,
-        py::arg("size"),              //
-        py::arg("vec").noconvert(),   //
-        py::arg("result").noconvert() //
-  );
+  // cbrt function
+  register_unary_function<double, std::cbrt, nb::device::cpu>(m, "cbrt");
+  register_unary_function<float, std::cbrt, nb::device::cpu>(m, "cbrt");
 }

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -12,7 +12,7 @@ compiler. To install `BrahMap`, please follow these steps:
 
 ```bash
 # Clone the repository
-git clone --recursive https://github.com/anand-avinash/BrahMap.git
+git clone https://github.com/anand-avinash/BrahMap.git
 
 # Enter the directory
 cd BrahMap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools",
     "setuptools_scm",
+    "nanobind",
     "mpi4py",         # `mpi4py` is needed to use `mpi4py.get_include()` in `setup.py`
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools._distutils.ccompiler import new_compiler
 import mpi4py
+import nanobind
 import threading
 from typing import Any, Iterator
 import tempfile
@@ -136,6 +137,15 @@ def update_git_hash():
 ### defining the dedicated build extension ###
 ##############################################
 
+# nanobind requires its runtime stub to be compiled into each extension.
+# nb_combined.cpp has an absolute path so it cannot go in Extension.sources
+# (setuptools rejects absolute paths there). Instead we pre-compile it once
+# in build_extensions() and inject the resulting .o via extra_objects.
+_nb_src = os.path.join(nanobind.source_dir(), "nb_combined.cpp")
+_nb_tsl_include = os.path.join(
+    os.path.dirname(nanobind.include_dir()), "ext", "robin_map", "include"
+)
+
 
 class brahmap_build_ext(build_ext):
     def get_environ_vars(self):
@@ -212,15 +222,28 @@ class brahmap_build_ext(build_ext):
         self.compiler.set_executable("linker_so", [MPICXX] + linker_flags + LDFLAGS)
         self.compiler.set_executable("linker_exe", [MPICXX] + linker_flags + LDFLAGS)
 
+        # Pre-compile nanobind's runtime stub once and share across all exts.
+        nb_obj = self.compiler.compile(
+            [_nb_src],
+            output_dir=self.build_temp,
+            include_dirs=[nanobind.include_dir(), _nb_tsl_include],
+            extra_postargs=compiler_so_args + CPPFLAGS + CXXFLAGS1 + CXXFLAGS2,
+        )
+        for ext in self.extensions:
+            ext.extra_objects = list(getattr(ext, "extra_objects", []) or []) + nb_obj
+
         super().build_extensions()
 
 
 ext1 = Extension(
     "brahmap._extensions.compute_weights",
-    sources=[os.path.join("brahmap", "_extensions", "compute_weights.cpp")],
+    sources=[
+        os.path.join("brahmap", "_extensions", "compute_weights.cpp"),
+    ],
     include_dirs=[
         os.path.join("brahmap", "_extensions"),
-        os.path.join("extern", "pybind11", "include"),
+        nanobind.include_dir(),
+        _nb_tsl_include,
         os.path.join(mpi4py.get_include()),
     ],
     define_macros=None,
@@ -229,10 +252,13 @@ ext1 = Extension(
 
 ext2 = Extension(
     "brahmap._extensions.repixelize",
-    sources=[os.path.join("brahmap", "_extensions", "repixelization.cpp")],
+    sources=[
+        os.path.join("brahmap", "_extensions", "repixelization.cpp"),
+    ],
     include_dirs=[
         os.path.join("brahmap", "_extensions"),
-        os.path.join("extern", "pybind11", "include"),
+        nanobind.include_dir(),
+        _nb_tsl_include,
     ],
     define_macros=None,
     extra_link_args=linker_so_args,
@@ -240,10 +266,13 @@ ext2 = Extension(
 
 ext3 = Extension(
     "brahmap._extensions.PointingLO_tools",
-    sources=[os.path.join("brahmap", "_extensions", "PointingLO_tools.cpp")],
+    sources=[
+        os.path.join("brahmap", "_extensions", "PointingLO_tools.cpp"),
+    ],
     include_dirs=[
         os.path.join("brahmap", "_extensions"),
-        os.path.join("extern", "pybind11", "include"),
+        nanobind.include_dir(),
+        _nb_tsl_include,
         os.path.join(mpi4py.get_include()),
     ],
     define_macros=None,
@@ -252,10 +281,13 @@ ext3 = Extension(
 
 ext4 = Extension(
     "brahmap._extensions.BlkDiagPrecondLO_tools",
-    sources=[os.path.join("brahmap", "_extensions", "BlkDiagPrecondLO_tools.cpp")],
+    sources=[
+        os.path.join("brahmap", "_extensions", "BlkDiagPrecondLO_tools.cpp"),
+    ],
     include_dirs=[
         os.path.join("brahmap", "_extensions"),
-        os.path.join("extern", "pybind11", "include"),
+        nanobind.include_dir(),
+        _nb_tsl_include,
     ],
     define_macros=None,
     extra_link_args=linker_so_args,
@@ -263,9 +295,12 @@ ext4 = Extension(
 
 ext5 = Extension(
     "brahmap.math.linalg_tools",
-    sources=[os.path.join("brahmap", "math", "linalg_tools.cpp")],
+    sources=[
+        os.path.join("brahmap", "math", "linalg_tools.cpp"),
+    ],
     include_dirs=[
-        os.path.join("extern", "pybind11", "include"),
+        nanobind.include_dir(),
+        _nb_tsl_include,
     ],
     define_macros=None,
     extra_link_args=linker_so_args,
@@ -273,9 +308,12 @@ ext5 = Extension(
 
 ext6 = Extension(
     "brahmap.math.unary_functions",
-    sources=[os.path.join("brahmap", "math", "unary_functions.cpp")],
+    sources=[
+        os.path.join("brahmap", "math", "unary_functions.cpp"),
+    ],
     include_dirs=[
-        os.path.join("extern", "pybind11", "include"),
+        nanobind.include_dir(),
+        _nb_tsl_include,
     ],
     define_macros=None,
     extra_link_args=linker_so_args,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ compiler_args = [
     "-fwrapv",
     "-fvisibility=hidden",
     "-std=c++20",
+    "-faligned-allocation",
 ]
 
 # These options are common with `compiler_so_args`. And since I am supplying

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ compiler_args = [
     "-fwrapv",
     "-fvisibility=hidden",
     "-std=c++20",
-    "-faligned-allocation",
 ]
 
 # These options are common with `compiler_so_args`. And since I am supplying
@@ -189,6 +188,12 @@ class brahmap_build_ext(build_ext):
             if check_flag(custom_compiler, item) is not None:
                 compiler_flags += [item]
                 break
+
+        # Check for macOS-specific aligned allocation flag
+        # can be removed once the support for python 3.11 is dropped
+        # (linked with a similar change in action workflow)
+        if check_flag(custom_compiler, "-faligned-allocation") is not None:
+            compiler_flags += ["-faligned-allocation"]
 
         return compiler_flags, linker_flags
 


### PR DESCRIPTION
This PR migrates the C++ extensions of BrahMap from `pybind11` to `nanobind`. While the `pybind11` based implementation worked very well and was generalized for array API support, `nanobind` makes the codebase easier to maintain without losing any capabilities (see [this](https://nanobind.readthedocs.io/en/latest/why.html) and [that](https://nanobind.readthedocs.io/en/latest/benchmark.html)). We made this change to improve the robustness of the codebase, simplify the binding logic, and ensure better compatibility with the modern Python Array API. The key changes include the following:

1. Unified Array Interface: While `pybind11` requires managing buffer protocols or specific NumPy interfaces, `nanobind` offers a unified interface for arrays following the Array API protocol. This allows the same binding code to handle arrays from NumPy, Dask, JAX, and other backends. We have replaced the previous `py::buffer / py::buffer_info` and `reinterpret_cast` logic with `nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>`. This provides direct, typed access to data via `arr.data()` without manual pointer casting.

2. Build System Integration: `nanobind` has been added as a build-system requirement rather than a runtime dependency or a submodule. This avoids potential version conflicts with other packages in the user's environment and complexities associated with submodules.

3. Template Registration Pattern: The binding code has been refactored to use a master registration template pattern. Instead of explicitly instantiating functions for each template argument pair in the module scope, we now define a single templated function that handles registration. This reduces code redundancy, improves readability, and drastically reduces the volume of hand-managed code.

4. Contiguity Handling: It was observed that operations like `scipy.fft.ifft().real` produce non-contiguous arrays, which can lead to incorrect results if passed directly to C++ routines. We now ensure arrays are made contiguous before being passed to functions such as `linalg_tools.multiply_array()`. Furthermore, the bindings now enforce this at the type level using the `nb::c_contig` template parameter.

5. Enforcement of Zero-Copy: To guarantee zero-copy execution and prevent implicit casting (which may create silent array copies), we have applied the `nb::arg().noconvert()` option to all relevant arguments. Additionally, we have structured the instantiation order to prioritize double types before float types to ensure correct overload resolution.

6. Explicit Constraints: We have explicitly added `nb::ndim<1>` and `nb::device::cpu` to `nb::ndarray` declarations across the extension modules to ensure stricter runtime verification of array dimensions and location.