### PR TITLE
Updating litebird_sim interface with regards to upcoming changes

### DIFF
--- a/brahmap/lbsim/lbsim_process_time_samples.py
+++ b/brahmap/lbsim/lbsim_process_time_samples.py
@@ -8,6 +8,11 @@ import litebird_sim as lbs
 from ..core import SolverType, ProcessTimeSamples
 from ..math import DTypeFloat
 
+if hasattr(lbs, "observation_utilities"):
+    pointing_tools = lbs.observation_utilities
+else:
+    pointing_tools = lbs.pointings_in_obs
+
 
 class LBSimProcessTimeSamples(ProcessTimeSamples):
     """A data container to store the pre-processed and pre-computed arrays and
@@ -71,7 +76,7 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
         (
             self.__obs_list,
             ptg_list,
-        ) = lbs.pointings_in_obs._normalize_observations_and_pointings(
+        ) = pointing_tools._normalize_observations_and_pointings(
             observations=observations, pointings=pointings
         )
 
@@ -88,7 +93,7 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
             if hwp is None:
                 hwp_angle = None
             else:
-                hwp_angle = lbs.pointings_in_obs._get_hwp_angle(
+                hwp_angle = pointing_tools._get_hwp_angle(
                     obs=obs, hwp=hwp, pointing_dtype=dtype_float
                 )
 
@@ -98,7 +103,7 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
                 (
                     curr_pointings_det,
                     hwp_angle,
-                ) = lbs.pointings_in_obs._get_pointings_array(
+                ) = pointing_tools._get_pointings_array(
                     detector_idx=det_idx,
                     pointings=curr_pointings,
                     hwp_angle=hwp_angle,
@@ -108,7 +113,7 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
 
                 end_idx += obs.n_samples
 
-                pol_angles[start_idx:end_idx] = lbs.pointings_in_obs._get_pol_angle(
+                pol_angles[start_idx:end_idx] = pointing_tools._get_pol_angle(
                     curr_pointings_det=curr_pointings_det,
                     hwp_angle=hwp_angle,
                     pol_angle_detectors=obs.pol_angle_rad[det_idx],

--- a/brahmap/lbsim/lbsim_process_time_samples.py
+++ b/brahmap/lbsim/lbsim_process_time_samples.py
@@ -4,9 +4,11 @@ import numpy as np
 import numpy.typing as npt
 import healpy as hp
 import litebird_sim as lbs
+from ducc0.healpix import Healpix_Base
 
 from ..core import SolverType, ProcessTimeSamples
 from ..math import DTypeFloat
+from ..mpi import MPI_UTILS
 
 if hasattr(lbs, "observation_utilities"):
     pointing_tools = lbs.observation_utilities
@@ -72,6 +74,7 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
         self.__nside = nside
         self.__coordinate_system = output_coordinate_system
         npix = hp.nside2npix(self.nside)
+        hpx = Healpix_Base(nside, "RING")
 
         (
             self.__obs_list,
@@ -109,6 +112,7 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
                     hwp_angle=hwp_angle,
                     output_coordinate_system=output_coordinate_system,
                     pointings_dtype=dtype_float,
+                    nthreads=MPI_UTILS.nthreads_per_process,
                 )
 
                 end_idx += obs.n_samples
@@ -119,8 +123,9 @@ class LBSimProcessTimeSamples(ProcessTimeSamples):
                     pol_angle_detectors=obs.pol_angle_rad[det_idx],
                 )
 
-                pix_indices[start_idx:end_idx] = hp.ang2pix(
-                    nside, curr_pointings_det[:, 0], curr_pointings_det[:, 1]
+                pix_indices[start_idx:end_idx] = hpx.ang2pix(
+                    curr_pointings_det[:, :2],
+                    nthreads=MPI_UTILS.nthreads_per_process,
                 )
 
                 start_idx = end_idx

--- a/brahmap/lbsim/lbsim_process_time_samples.py
+++ b/brahmap/lbsim/lbsim_process_time_samples.py
@@ -10,6 +10,7 @@ from ..core import SolverType, ProcessTimeSamples
 from ..math import DTypeFloat
 from ..mpi import MPI_UTILS
 
+# For backwards compatibility with lbs v0.17.0 and earlier
 if hasattr(lbs, "observation_utilities"):
     pointing_tools = lbs.observation_utilities
 else:

--- a/tests/test_noise_ops_blockdiag_toeplitz.py
+++ b/tests/test_noise_ops_blockdiag_toeplitz.py
@@ -33,6 +33,7 @@ class BlockDiagNoiseOps_Toeplitz(BaseTestNoiseLO):
 
         for idx in range(nblocks):
             covariance = rng.random(block_size[idx], dtype=dtype)
+            covariance[0] += np.sum(np.abs(covariance))
             extended_covariance = np.concatenate([covariance, covariance[1:-1][::-1]])
             power_spec = scipy.fft.fft(extended_covariance).real.astype(
                 dtype


### PR DESCRIPTION
The upcoming changes to `litebird_sim` renames the sub-module `pointings_in_obs` with `observation_utilities` [PR#538](https://github.com/litebird/litebird_sim/pull/538). This PR addresses this change. In addition, we have also adopted `Healpix_Base` from `ducc0` for `ang2pix()` computations in the `lbsim` interface, enabling multi-threaded computation of pixel index computations.